### PR TITLE
feat(backend): iCal feed per team

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.3.1",
         "helmet": "^8.1.0",
+        "ics": "^3.11.0",
         "ioredis": "^5.3.2",
         "kafkajs": "^2.2.4",
         "pg": "^8.20.0",
@@ -6395,6 +6396,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ics": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/ics/-/ics-3.11.0.tgz",
+      "integrity": "sha512-uDB3GEOYRSZL2BgxLZkHUDwcHqjC36gGuKBrFatl7BtMNQKzO2rXkCj0zTl/QyP9lfyAEp2WZU2XBZciaLJZZw==",
+      "license": "ISC",
+      "dependencies": {
+        "nanoid": "^3.1.23",
+        "runes2": "^1.1.2",
+        "yup": "^1.2.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -7678,6 +7690,24 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -8366,6 +8396,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -8611,6 +8647,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/runes2": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/runes2/-/runes2-1.1.4.tgz",
+      "integrity": "sha512-LNPnEDPOOU4ehF71m5JoQyzT2yxwD6ZreFJ7MxZUAoMKNMY1XrAo60H1CUoX5ncSm0rIuKlqn9JZNRrRkNou2g==",
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -9135,6 +9177,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -9207,6 +9255,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -9877,6 +9931,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
+      "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.1",
     "helmet": "^8.1.0",
+    "ics": "^3.11.0",
     "ioredis": "^5.3.2",
     "kafkajs": "^2.2.4",
     "pg": "^8.20.0",

--- a/backend/prisma/migrations/20260412200823_add_calendar_feed_token/migration.sql
+++ b/backend/prisma/migrations/20260412200823_add_calendar_feed_token/migration.sql
@@ -1,0 +1,32 @@
+-- CreateTable
+CREATE TABLE "CalendarFeedToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CalendarFeedToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CalendarFeedToken_token_key" ON "CalendarFeedToken"("token");
+
+-- CreateIndex
+CREATE INDEX "CalendarFeedToken_userId_idx" ON "CalendarFeedToken"("userId");
+
+-- CreateIndex
+CREATE INDEX "CalendarFeedToken_teamId_idx" ON "CalendarFeedToken"("teamId");
+
+-- CreateIndex
+CREATE INDEX "CalendarFeedToken_userId_teamId_idx" ON "CalendarFeedToken"("userId", "teamId");
+
+-- CreateIndex
+CREATE INDEX "CalendarFeedToken_token_idx" ON "CalendarFeedToken"("token");
+
+-- AddForeignKey
+ALTER TABLE "CalendarFeedToken" ADD CONSTRAINT "CalendarFeedToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CalendarFeedToken" ADD CONSTRAINT "CalendarFeedToken_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -108,6 +108,7 @@ model User {
   gameRsvps           GameRsvp[]
   pushTokens          PushToken[]
   announcements       Announcement[]
+  calendarFeedTokens  CalendarFeedToken[]
 
   @@index([email])
   @@index([role])
@@ -218,6 +219,7 @@ model Team {
   invitations   TeamInvitation[]
   teamStats     TeamStats[]
   announcements Announcement[]
+  calendarFeedTokens CalendarFeedToken[]
 
   @@index([seasonId])
   @@index([name])
@@ -449,6 +451,27 @@ model PushToken {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
+}
+
+// =============================================================================
+// CALENDAR FEED TOKENS
+// =============================================================================
+
+model CalendarFeedToken {
+  id        String    @id @default(uuid())
+  userId    String
+  teamId    String
+  token     String    @unique
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  team Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([teamId])
+  @@index([userId, teamId])
+  @@index([token])
 }
 
 // =============================================================================

--- a/backend/src/api/index.ts
+++ b/backend/src/api/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import authRoutes from './auth/routes';
 import gameRoutes from './games/routes';
 import teamRoutes from './teams/routes';
+import teamCalendarRoutes from './teams/calendar';
 import leagueRoutes from './leagues/routes';
 import seasonRoutes from './seasons/routes';
 import playerRoutes from './players/routes';
@@ -14,6 +15,10 @@ const router = Router();
 // API routes
 router.use('/auth', authRoutes);
 router.use('/games', gameRoutes);
+// Calendar routes must be mounted before `/teams` so the public GET
+// /teams/:id/calendar.ics (token-auth) bypasses the authenticate middleware
+// used by the main teams router.
+router.use('/teams', teamCalendarRoutes);
 router.use('/teams', teamRoutes);
 router.use('/leagues', leagueRoutes);
 router.use('/seasons', seasonRoutes);

--- a/backend/src/api/middleware/rate-limit.ts
+++ b/backend/src/api/middleware/rate-limit.ts
@@ -39,3 +39,19 @@ export const writeRateLimit = rateLimit({
   legacyHeaders: false,
   message: { error: 'Too many write requests, please try again later' },
 });
+
+/**
+ * Rate limit for the public iCalendar feed endpoint.
+ *
+ * The feed is token-authenticated via query param (calendar clients can't
+ * send Authorization headers), so requests are rate-limited by IP to
+ * discourage abuse and token-guessing. Calendar clients typically poll every
+ * 15-60 minutes, so 60 requests per hour per IP is generous for legitimate use.
+ */
+export const calendarFeedRateLimit = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many calendar feed requests, please try again later' },
+});

--- a/backend/src/api/teams/calendar.ts
+++ b/backend/src/api/teams/calendar.ts
@@ -10,6 +10,7 @@ import { Router } from 'express';
 import { CalendarService } from '../../services/calendar-service';
 import { authenticate } from '../auth/middleware';
 import { validateUuidParams } from '../middleware/validate-params';
+import { calendarFeedRateLimit } from '../middleware/rate-limit';
 import {
   BadRequestError,
   NotFoundError,
@@ -26,7 +27,11 @@ const router = Router({ mergeParams: true });
  * Public: calendar clients can't send Authorization headers, so auth is
  * via an opaque `token` query parameter bound to a specific (user, team).
  */
-router.get('/:id/calendar.ics', validateUuidParams('id'), async (req, res) => {
+router.get(
+  '/:id/calendar.ics',
+  calendarFeedRateLimit,
+  validateUuidParams('id'),
+  async (req, res) => {
   try {
     const teamId = req.params.id as string;
     const token = typeof req.query.token === 'string' ? req.query.token : '';
@@ -55,7 +60,8 @@ router.get('/:id/calendar.ics', validateUuidParams('id'), async (req, res) => {
       res.status(500).json({ error: 'Failed to generate calendar feed' });
     }
   }
-});
+  }
+);
 
 // All management endpoints require authentication.
 router.use(authenticate);

--- a/backend/src/api/teams/calendar.ts
+++ b/backend/src/api/teams/calendar.ts
@@ -1,0 +1,133 @@
+/**
+ * Calendar feed routes for a team.
+ *
+ *   GET  /api/v1/teams/:id/calendar.ics?token=... (public, token-auth)
+ *   POST /api/v1/teams/:id/calendar/subscribe    (authenticated)
+ *   POST /api/v1/teams/:id/calendar/revoke       (authenticated)
+ */
+
+import { Router } from 'express';
+import { CalendarService } from '../../services/calendar-service';
+import { authenticate } from '../auth/middleware';
+import { validateUuidParams } from '../middleware/validate-params';
+import {
+  BadRequestError,
+  NotFoundError,
+  ForbiddenError,
+  AppError,
+} from '../../utils/errors';
+import { logger } from '../../utils/logger';
+
+const router = Router({ mergeParams: true });
+
+/**
+ * GET /api/v1/teams/:id/calendar.ics
+ *
+ * Public: calendar clients can't send Authorization headers, so auth is
+ * via an opaque `token` query parameter bound to a specific (user, team).
+ */
+router.get('/:id/calendar.ics', validateUuidParams('id'), async (req, res) => {
+  try {
+    const teamId = req.params.id as string;
+    const token = typeof req.query.token === 'string' ? req.query.token : '';
+
+    // Resolve + authorize the token. Throws ForbiddenError on revoked,
+    // mismatched, or stale tokens.
+    await CalendarService.resolveToken(teamId, token);
+
+    const icsText = await CalendarService.buildFeed(teamId);
+
+    res.setHeader('Content-Type', 'text/calendar; charset=utf-8');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="team-${teamId}.ics"`
+    );
+    // Calendar clients re-fetch periodically; discourage caching so edits appear quickly.
+    res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.status(200).send(icsText);
+  } catch (error) {
+    logger.error('Error serving calendar feed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    if (error instanceof AppError) {
+      res.status(error.statusCode).json({ error: error.message });
+    } else {
+      res.status(500).json({ error: 'Failed to generate calendar feed' });
+    }
+  }
+});
+
+// All management endpoints require authentication.
+router.use(authenticate);
+
+/**
+ * POST /api/v1/teams/:id/calendar/subscribe
+ * Returns (and creates if missing) the user's feed URL for this team.
+ */
+router.post(
+  '/:id/calendar/subscribe',
+  validateUuidParams('id'),
+  async (req, res) => {
+    try {
+      const result = await CalendarService.subscribe(
+        req.params.id as string,
+        req.user!.id
+      );
+
+      res.status(200).json({
+        success: true,
+        ...result,
+      });
+    } catch (error) {
+      logger.error('Error subscribing to calendar feed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      if (
+        error instanceof NotFoundError ||
+        error instanceof ForbiddenError ||
+        error instanceof BadRequestError
+      ) {
+        res.status(error.statusCode).json({ error: error.message });
+      } else {
+        res.status(500).json({ error: 'Failed to subscribe to calendar feed' });
+      }
+    }
+  }
+);
+
+/**
+ * POST /api/v1/teams/:id/calendar/revoke
+ * Invalidates all of the user's calendar feed tokens for this team.
+ */
+router.post(
+  '/:id/calendar/revoke',
+  validateUuidParams('id'),
+  async (req, res) => {
+    try {
+      const result = await CalendarService.revoke(
+        req.params.id as string,
+        req.user!.id
+      );
+
+      res.status(200).json({
+        success: true,
+        ...result,
+      });
+    } catch (error) {
+      logger.error('Error revoking calendar feed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      if (
+        error instanceof NotFoundError ||
+        error instanceof ForbiddenError ||
+        error instanceof BadRequestError
+      ) {
+        res.status(error.statusCode).json({ error: error.message });
+      } else {
+        res.status(500).json({ error: 'Failed to revoke calendar feed' });
+      }
+    }
+  }
+);
+
+export default router;

--- a/backend/src/services/calendar-service.ts
+++ b/backend/src/services/calendar-service.ts
@@ -1,0 +1,226 @@
+/**
+ * Calendar feed service — generates iCalendar (RFC 5545) feeds for a team's
+ * games and manages per-user, per-team opaque feed tokens.
+ */
+
+import { randomBytes } from 'crypto';
+import { createEvents, EventAttributes, DateArray } from 'ics';
+import prisma from '../models';
+import { NotFoundError, ForbiddenError, BadRequestError } from '../utils/errors';
+import { canAccessTeam } from '../utils/permissions';
+
+// Assume games run ~2 hours. Game model has only a start `date`.
+const DEFAULT_GAME_DURATION_HOURS = 2;
+
+/**
+ * Public base URL for deep links back to games. Falls back to localhost in dev.
+ */
+function getPublicAppUrl(): string {
+  return process.env.PUBLIC_APP_URL || process.env.API_BASE_URL || 'http://localhost:3000';
+}
+
+function dateToDateArray(d: Date): DateArray {
+  return [
+    d.getUTCFullYear(),
+    d.getUTCMonth() + 1,
+    d.getUTCDate(),
+    d.getUTCHours(),
+    d.getUTCMinutes(),
+  ];
+}
+
+function statusToIcalStatus(status: string): 'CONFIRMED' | 'TENTATIVE' | 'CANCELLED' {
+  switch (status) {
+    case 'CANCELLED':
+      return 'CANCELLED';
+    case 'SCHEDULED':
+      return 'TENTATIVE';
+    case 'IN_PROGRESS':
+    case 'FINISHED':
+    default:
+      return 'CONFIRMED';
+  }
+}
+
+export class CalendarService {
+  /**
+   * Generate a new opaque token (base64url-encoded 32 random bytes).
+   */
+  static generateTokenString(): string {
+    return randomBytes(32).toString('base64url');
+  }
+
+  /**
+   * Subscribe a user to a team's calendar feed. Creates an active token if
+   * none exists for the (user, team) pair, otherwise returns the existing one.
+   * Caller must have access to the team.
+   */
+  static async subscribe(teamId: string, userId: string): Promise<{
+    token: string;
+    feedUrl: string;
+    webcalUrl: string;
+  }> {
+    // Verify team exists
+    const team = await prisma.team.findUnique({ where: { id: teamId } });
+    if (!team) {
+      throw new NotFoundError('Team not found');
+    }
+
+    // Must have access to the team
+    const hasAccess = await canAccessTeam(userId, teamId);
+    if (!hasAccess) {
+      throw new ForbiddenError('You do not have access to this team');
+    }
+
+    // Reuse an active token if one exists for this (user, team)
+    const existing = await prisma.calendarFeedToken.findFirst({
+      where: { userId, teamId, revokedAt: null },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    const tokenRow = existing
+      ? existing
+      : await prisma.calendarFeedToken.create({
+          data: {
+            userId,
+            teamId,
+            token: CalendarService.generateTokenString(),
+          },
+        });
+
+    const base = getPublicAppUrl().replace(/\/$/, '');
+    const path = `/api/v1/teams/${teamId}/calendar.ics?token=${encodeURIComponent(
+      tokenRow.token
+    )}`;
+    const httpUrl = `${base}${path}`;
+    // webcal:// — strip scheme for calendar-client subscription
+    const webcalUrl = httpUrl.replace(/^https?:\/\//, 'webcal://');
+
+    return {
+      token: tokenRow.token,
+      feedUrl: httpUrl,
+      webcalUrl,
+    };
+  }
+
+  /**
+   * Revoke all calendar feed tokens for the given (user, team) pair.
+   */
+  static async revoke(teamId: string, userId: string): Promise<{ revoked: number }> {
+    // Verify team exists — produce a nice 404 instead of a silent no-op.
+    const team = await prisma.team.findUnique({ where: { id: teamId } });
+    if (!team) {
+      throw new NotFoundError('Team not found');
+    }
+
+    const result = await prisma.calendarFeedToken.updateMany({
+      where: { userId, teamId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+
+    return { revoked: result.count };
+  }
+
+  /**
+   * Resolve a raw token string to its (userId, teamId), enforcing:
+   *   - token exists
+   *   - not revoked
+   *   - token's teamId matches the URL's teamId
+   *   - user still has access to the team
+   */
+  static async resolveToken(
+    teamId: string,
+    tokenString: string
+  ): Promise<{ userId: string; teamId: string }> {
+    if (!tokenString) {
+      throw new BadRequestError('Missing calendar token');
+    }
+
+    const tokenRow = await prisma.calendarFeedToken.findUnique({
+      where: { token: tokenString },
+    });
+
+    if (!tokenRow) {
+      throw new ForbiddenError('Invalid calendar token');
+    }
+
+    if (tokenRow.revokedAt) {
+      throw new ForbiddenError('Calendar token has been revoked');
+    }
+
+    if (tokenRow.teamId !== teamId) {
+      throw new ForbiddenError('Calendar token does not match team');
+    }
+
+    // Confirm the user still has access to this team. If not, deny.
+    const hasAccess = await canAccessTeam(tokenRow.userId, tokenRow.teamId);
+    if (!hasAccess) {
+      throw new ForbiddenError('User no longer has access to this team');
+    }
+
+    return { userId: tokenRow.userId, teamId: tokenRow.teamId };
+  }
+
+  /**
+   * Build the iCalendar text for the given team's games.
+   * Includes SCHEDULED, IN_PROGRESS, and FINISHED games (and CANCELLED ones
+   * marked STATUS:CANCELLED so subscribers see cancellations).
+   */
+  static async buildFeed(teamId: string): Promise<string> {
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      select: { id: true, name: true },
+    });
+
+    if (!team) {
+      throw new NotFoundError('Team not found');
+    }
+
+    const games = await prisma.game.findMany({
+      where: { teamId },
+      orderBy: { date: 'asc' },
+    });
+
+    const base = getPublicAppUrl().replace(/\/$/, '');
+
+    const events: EventAttributes[] = games.map((game) => {
+      const start = new Date(game.date);
+      const end = new Date(
+        start.getTime() + DEFAULT_GAME_DURATION_HOURS * 60 * 60 * 1000
+      );
+
+      const title = `${team.name} vs ${game.opponent}`;
+      const descriptionLines = [
+        `Status: ${game.status}`,
+        game.status === 'FINISHED'
+          ? `Final score: ${game.homeScore}-${game.awayScore}`
+          : null,
+        `View game: ${base}/games/${game.id}`,
+      ].filter((l): l is string => !!l);
+
+      return {
+        uid: `game-${game.id}@capyhoops.com`,
+        start: dateToDateArray(start),
+        startInputType: 'utc',
+        end: dateToDateArray(end),
+        endInputType: 'utc',
+        title,
+        description: descriptionLines.join('\n'),
+        url: `${base}/games/${game.id}`,
+        status: statusToIcalStatus(game.status),
+        categories: ['Basketball', team.name],
+      };
+    });
+
+    const { error, value } = createEvents(events, {
+      calName: `${team.name} — Basketball Schedule`,
+      productId: 'capyhoops/ical',
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    return value || '';
+  }
+}

--- a/backend/tests/api/calendar.test.ts
+++ b/backend/tests/api/calendar.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Calendar Feed API Integration Tests
+ *
+ * Covers:
+ *   - POST /api/v1/teams/:id/calendar/subscribe
+ *   - POST /api/v1/teams/:id/calendar/revoke
+ *   - GET  /api/v1/teams/:id/calendar.ics?token=...
+ */
+
+import request from 'supertest';
+import { app, httpServer } from '../../src/index';
+import { CalendarService } from '../../src/services/calendar-service';
+import {
+  NotFoundError,
+  ForbiddenError,
+  BadRequestError,
+} from '../../src/utils/errors';
+
+const TEST_USER_ID = 'a1b2c3d4-e5f6-4890-a234-567890abcdef';
+const TEST_TEAM_ID = 'b2c3d4e5-f6a7-4901-a345-67890abcdef0';
+
+jest.mock('../../src/api/auth/middleware', () => ({
+  authenticate: jest.fn((req, _res, next) => {
+    req.user = {
+      id: 'a1b2c3d4-e5f6-4890-a234-567890abcdef',
+      email: 'test@example.com',
+      name: 'Test User',
+      role: 'COACH',
+    };
+    next();
+  }),
+  requireRole: jest.fn(() => (_req: any, _res: any, next: any) => next()),
+}));
+
+jest.mock('../../src/services/calendar-service');
+
+const mockCalendarService = CalendarService as jest.Mocked<typeof CalendarService>;
+
+describe('Calendar Feed API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /api/v1/teams/:id/calendar/subscribe', () => {
+    it('returns a feed URL for an authorized user', async () => {
+      mockCalendarService.subscribe.mockResolvedValue({
+        token: 'abc123',
+        feedUrl: `http://localhost:3000/api/v1/teams/${TEST_TEAM_ID}/calendar.ics?token=abc123`,
+        webcalUrl: `webcal://localhost:3000/api/v1/teams/${TEST_TEAM_ID}/calendar.ics?token=abc123`,
+      });
+
+      const res = await request(app).post(
+        `/api/v1/teams/${TEST_TEAM_ID}/calendar/subscribe`
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.token).toBe('abc123');
+      expect(res.body.feedUrl).toContain(`/teams/${TEST_TEAM_ID}/calendar.ics`);
+      expect(res.body.webcalUrl.startsWith('webcal://')).toBe(true);
+      expect(mockCalendarService.subscribe).toHaveBeenCalledWith(
+        TEST_TEAM_ID,
+        TEST_USER_ID
+      );
+    });
+
+    it('returns 403 when the user has no access to the team', async () => {
+      mockCalendarService.subscribe.mockRejectedValue(
+        new ForbiddenError('You do not have access to this team')
+      );
+
+      const res = await request(app).post(
+        `/api/v1/teams/${TEST_TEAM_ID}/calendar/subscribe`
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 404 when the team does not exist', async () => {
+      mockCalendarService.subscribe.mockRejectedValue(new NotFoundError('Team not found'));
+
+      const res = await request(app).post(
+        `/api/v1/teams/00000000-0000-0000-0000-000000000000/calendar/subscribe`
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 400 for an invalid team id (non-UUID)', async () => {
+      const res = await request(app).post('/api/v1/teams/not-a-uuid/calendar/subscribe');
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /api/v1/teams/:id/calendar/revoke', () => {
+    it('revokes the user\'s tokens for a team', async () => {
+      mockCalendarService.revoke.mockResolvedValue({ revoked: 2 });
+
+      const res = await request(app).post(
+        `/api/v1/teams/${TEST_TEAM_ID}/calendar/revoke`
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.revoked).toBe(2);
+    });
+
+    it('returns 404 for an unknown team', async () => {
+      mockCalendarService.revoke.mockRejectedValue(new NotFoundError('Team not found'));
+      const res = await request(app).post(
+        `/api/v1/teams/00000000-0000-0000-0000-000000000000/calendar/revoke`
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /api/v1/teams/:id/calendar.ics', () => {
+    it('returns a valid iCalendar body with text/calendar content type', async () => {
+      mockCalendarService.resolveToken.mockResolvedValue({
+        userId: TEST_USER_ID,
+        teamId: TEST_TEAM_ID,
+      });
+      mockCalendarService.buildFeed.mockResolvedValue(
+        'BEGIN:VCALENDAR\nEND:VCALENDAR'
+      );
+
+      const res = await request(app).get(
+        `/api/v1/teams/${TEST_TEAM_ID}/calendar.ics?token=goodtoken`
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/text\/calendar/);
+      expect(res.text).toContain('BEGIN:VCALENDAR');
+      expect(mockCalendarService.resolveToken).toHaveBeenCalledWith(
+        TEST_TEAM_ID,
+        'goodtoken'
+      );
+    });
+
+    it('returns 400 when the token is missing', async () => {
+      mockCalendarService.resolveToken.mockRejectedValue(
+        new BadRequestError('Missing calendar token')
+      );
+
+      const res = await request(app).get(
+        `/api/v1/teams/${TEST_TEAM_ID}/calendar.ics`
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 403 for a revoked token', async () => {
+      mockCalendarService.resolveToken.mockRejectedValue(
+        new ForbiddenError('Calendar token has been revoked')
+      );
+
+      const res = await request(app).get(
+        `/api/v1/teams/${TEST_TEAM_ID}/calendar.ics?token=revoked`
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 403 when token belongs to a different team', async () => {
+      mockCalendarService.resolveToken.mockRejectedValue(
+        new ForbiddenError('Calendar token does not match team')
+      );
+
+      const res = await request(app).get(
+        `/api/v1/teams/${TEST_TEAM_ID}/calendar.ics?token=othertoken`
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 403 when the user no longer has access to the team', async () => {
+      mockCalendarService.resolveToken.mockRejectedValue(
+        new ForbiddenError('User no longer has access to this team')
+      );
+
+      const res = await request(app).get(
+        `/api/v1/teams/${TEST_TEAM_ID}/calendar.ics?token=stale`
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it('still returns an empty calendar when team has no games', async () => {
+      mockCalendarService.resolveToken.mockResolvedValue({
+        userId: TEST_USER_ID,
+        teamId: TEST_TEAM_ID,
+      });
+      mockCalendarService.buildFeed.mockResolvedValue(
+        'BEGIN:VCALENDAR\nEND:VCALENDAR'
+      );
+
+      const res = await request(app).get(
+        `/api/v1/teams/${TEST_TEAM_ID}/calendar.ics?token=good`
+      );
+      expect(res.status).toBe(200);
+      expect(res.text).not.toContain('BEGIN:VEVENT');
+    });
+
+    it('returns 400 for a non-UUID team id', async () => {
+      const res = await request(app).get('/api/v1/teams/not-a-uuid/calendar.ics?token=x');
+      expect(res.status).toBe(400);
+    });
+  });
+});
+
+afterAll((done) => {
+  if (httpServer) {
+    httpServer.close(() => done());
+  } else {
+    done();
+  }
+});

--- a/backend/tests/services/calendar-service.test.ts
+++ b/backend/tests/services/calendar-service.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Unit tests for CalendarService
+ */
+
+import { CalendarService } from '../../src/services/calendar-service';
+import { mockPrisma } from '../setup';
+import { createTeam, createGame, createUser } from '../factories';
+import {
+  expectNotFoundError,
+  expectForbiddenError,
+} from '../helpers';
+
+// Mock canAccessTeam via the permissions module
+jest.mock('../../src/utils/permissions', () => ({
+  ...jest.requireActual('../../src/utils/permissions'),
+  canAccessTeam: jest.fn(),
+}));
+
+import { canAccessTeam } from '../../src/utils/permissions';
+
+describe('CalendarService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('subscribe', () => {
+    it('creates a new token when none exists', async () => {
+      const team = createTeam();
+      const user = createUser();
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (canAccessTeam as jest.Mock).mockResolvedValue(true);
+      (mockPrisma.calendarFeedToken.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.calendarFeedToken.create as jest.Mock).mockImplementation(
+        ({ data }: { data: { userId: string; teamId: string; token: string } }) => ({
+          id: 'token-id',
+          ...data,
+          revokedAt: null,
+          createdAt: new Date(),
+        })
+      );
+
+      const result = await CalendarService.subscribe(team.id, user.id);
+
+      expect(mockPrisma.calendarFeedToken.create).toHaveBeenCalledTimes(1);
+      expect(result.token).toBeTruthy();
+      expect(result.feedUrl).toContain(`/api/v1/teams/${team.id}/calendar.ics`);
+      expect(result.feedUrl).toContain(`token=${encodeURIComponent(result.token)}`);
+      expect(result.webcalUrl.startsWith('webcal://')).toBe(true);
+    });
+
+    it('reuses an existing active token', async () => {
+      const team = createTeam();
+      const user = createUser();
+      const existing = {
+        id: 'existing-token',
+        userId: user.id,
+        teamId: team.id,
+        token: 'EXISTING_TOKEN',
+        revokedAt: null,
+        createdAt: new Date(),
+      };
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (canAccessTeam as jest.Mock).mockResolvedValue(true);
+      (mockPrisma.calendarFeedToken.findFirst as jest.Mock).mockResolvedValue(existing);
+
+      const result = await CalendarService.subscribe(team.id, user.id);
+
+      expect(mockPrisma.calendarFeedToken.create).not.toHaveBeenCalled();
+      expect(result.token).toBe('EXISTING_TOKEN');
+    });
+
+    it('throws NotFoundError when team does not exist', async () => {
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await CalendarService.subscribe('missing-team', 'user-id');
+        fail('expected NotFoundError');
+      } catch (error) {
+        expectNotFoundError(error, 'Team not found');
+      }
+    });
+
+    it('throws ForbiddenError when user cannot access team', async () => {
+      const team = createTeam();
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (canAccessTeam as jest.Mock).mockResolvedValue(false);
+
+      try {
+        await CalendarService.subscribe(team.id, 'outside-user');
+        fail('expected ForbiddenError');
+      } catch (error) {
+        expectForbiddenError(error);
+      }
+    });
+  });
+
+  describe('revoke', () => {
+    it('marks all active tokens as revoked', async () => {
+      const team = createTeam();
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.calendarFeedToken.updateMany as jest.Mock).mockResolvedValue({
+        count: 3,
+      });
+
+      const result = await CalendarService.revoke(team.id, 'user-id');
+      expect(result.revoked).toBe(3);
+      expect(mockPrisma.calendarFeedToken.updateMany).toHaveBeenCalledWith({
+        where: { userId: 'user-id', teamId: team.id, revokedAt: null },
+        data: { revokedAt: expect.any(Date) },
+      });
+    });
+
+    it('throws NotFoundError when team does not exist', async () => {
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await CalendarService.revoke('missing', 'user');
+        fail('expected NotFoundError');
+      } catch (error) {
+        expectNotFoundError(error);
+      }
+    });
+  });
+
+  describe('resolveToken', () => {
+    it('resolves a valid token', async () => {
+      const team = createTeam();
+      const tokenRow = {
+        id: 'id',
+        userId: 'user-1',
+        teamId: team.id,
+        token: 'abc',
+        revokedAt: null,
+        createdAt: new Date(),
+      };
+      (mockPrisma.calendarFeedToken.findUnique as jest.Mock).mockResolvedValue(tokenRow);
+      (canAccessTeam as jest.Mock).mockResolvedValue(true);
+
+      const res = await CalendarService.resolveToken(team.id, 'abc');
+      expect(res).toEqual({ userId: 'user-1', teamId: team.id });
+    });
+
+    it('rejects missing token with BadRequest', async () => {
+      await expect(CalendarService.resolveToken('t', '')).rejects.toThrow(/Missing/);
+    });
+
+    it('rejects unknown token with Forbidden', async () => {
+      (mockPrisma.calendarFeedToken.findUnique as jest.Mock).mockResolvedValue(null);
+      await expect(CalendarService.resolveToken('t', 'nope')).rejects.toThrow(/Invalid/);
+    });
+
+    it('rejects revoked token', async () => {
+      (mockPrisma.calendarFeedToken.findUnique as jest.Mock).mockResolvedValue({
+        id: 'id',
+        userId: 'u',
+        teamId: 't',
+        token: 'abc',
+        revokedAt: new Date(),
+        createdAt: new Date(),
+      });
+      await expect(CalendarService.resolveToken('t', 'abc')).rejects.toThrow(/revoked/);
+    });
+
+    it('rejects token whose teamId does not match the URL', async () => {
+      (mockPrisma.calendarFeedToken.findUnique as jest.Mock).mockResolvedValue({
+        id: 'id',
+        userId: 'u',
+        teamId: 'team-A',
+        token: 'abc',
+        revokedAt: null,
+        createdAt: new Date(),
+      });
+      await expect(
+        CalendarService.resolveToken('team-B', 'abc')
+      ).rejects.toThrow(/does not match/);
+    });
+
+    it('rejects when user no longer has team access', async () => {
+      (mockPrisma.calendarFeedToken.findUnique as jest.Mock).mockResolvedValue({
+        id: 'id',
+        userId: 'u',
+        teamId: 't',
+        token: 'abc',
+        revokedAt: null,
+        createdAt: new Date(),
+      });
+      (canAccessTeam as jest.Mock).mockResolvedValue(false);
+      await expect(
+        CalendarService.resolveToken('t', 'abc')
+      ).rejects.toThrow(/no longer has access/);
+    });
+  });
+
+  describe('buildFeed', () => {
+    it('returns a valid iCalendar document with events for all game statuses', async () => {
+      const team = createTeam({ name: 'Lakers' });
+      const games = [
+        createGame({ teamId: team.id, status: 'SCHEDULED', opponent: 'Celtics' }),
+        createGame({ teamId: team.id, status: 'IN_PROGRESS', opponent: 'Bulls' }),
+        createGame({
+          teamId: team.id,
+          status: 'FINISHED',
+          opponent: 'Heat',
+          homeScore: 95,
+          awayScore: 90,
+        }),
+        createGame({ teamId: team.id, status: 'CANCELLED', opponent: 'Nets' }),
+      ];
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue({
+        id: team.id,
+        name: team.name,
+      });
+      (mockPrisma.game.findMany as jest.Mock).mockResolvedValue(games);
+
+      const ics = await CalendarService.buildFeed(team.id);
+
+      expect(ics).toContain('BEGIN:VCALENDAR');
+      expect(ics).toContain('END:VCALENDAR');
+      // One VEVENT per game
+      const eventMatches = ics.match(/BEGIN:VEVENT/g) || [];
+      expect(eventMatches.length).toBe(4);
+      expect(ics).toContain('Lakers vs Celtics');
+      expect(ics).toContain('STATUS:CANCELLED');
+      expect(ics).toContain('STATUS:TENTATIVE'); // SCHEDULED
+      expect(ics).toContain('Final score: 95-90');
+    });
+
+    it('returns an empty-but-valid calendar when team has no games', async () => {
+      const team = createTeam({ name: 'Nomads' });
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue({
+        id: team.id,
+        name: team.name,
+      });
+      (mockPrisma.game.findMany as jest.Mock).mockResolvedValue([]);
+
+      const ics = await CalendarService.buildFeed(team.id);
+      expect(ics).toContain('BEGIN:VCALENDAR');
+      expect(ics).toContain('END:VCALENDAR');
+      expect(ics).not.toContain('BEGIN:VEVENT');
+    });
+
+    it('throws NotFoundError if team does not exist', async () => {
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(null);
+      await expect(CalendarService.buildFeed('missing')).rejects.toThrow(/Team not found/);
+    });
+  });
+
+  describe('generateTokenString', () => {
+    it('returns distinct opaque strings of reasonable length', () => {
+      const a = CalendarService.generateTokenString();
+      const b = CalendarService.generateTokenString();
+      expect(a).not.toEqual(b);
+      expect(a.length).toBeGreaterThanOrEqual(32);
+      // base64url: no + / = characters
+      expect(a).not.toMatch(/[+/=]/);
+    });
+  });
+});

--- a/backend/tests/services/calendar-service.test.ts
+++ b/backend/tests/services/calendar-service.test.ts
@@ -122,6 +122,68 @@ describe('CalendarService', () => {
         expectNotFoundError(error);
       }
     });
+
+    it('resubscribing after revoke issues a NEW token and the old token no longer resolves', async () => {
+      const team = createTeam();
+      const user = createUser();
+
+      // --- Step 1: initial subscribe → token A ---
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (canAccessTeam as jest.Mock).mockResolvedValue(true);
+      (mockPrisma.calendarFeedToken.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.calendarFeedToken.create as jest.Mock).mockImplementation(
+        ({ data }: { data: { userId: string; teamId: string; token: string } }) => ({
+          id: 'token-a-id',
+          ...data,
+          revokedAt: null,
+          createdAt: new Date(),
+        })
+      );
+
+      const firstSub = await CalendarService.subscribe(team.id, user.id);
+      const tokenA = firstSub.token;
+      expect(tokenA).toBeTruthy();
+
+      // --- Step 2: revoke ---
+      (mockPrisma.calendarFeedToken.updateMany as jest.Mock).mockResolvedValue({
+        count: 1,
+      });
+      const revokeResult = await CalendarService.revoke(team.id, user.id);
+      expect(revokeResult.revoked).toBe(1);
+
+      // --- Step 3: subscribe again → findFirst now returns null (no active
+      // tokens remain after revoke), so a NEW token B is created ---
+      (mockPrisma.calendarFeedToken.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.calendarFeedToken.create as jest.Mock).mockImplementation(
+        ({ data }: { data: { userId: string; teamId: string; token: string } }) => ({
+          id: 'token-b-id',
+          ...data,
+          revokedAt: null,
+          createdAt: new Date(),
+        })
+      );
+
+      const secondSub = await CalendarService.subscribe(team.id, user.id);
+      const tokenB = secondSub.token;
+
+      expect(tokenB).toBeTruthy();
+      expect(tokenB).not.toEqual(tokenA);
+      // create() was called again (not reused)
+      expect(mockPrisma.calendarFeedToken.create).toHaveBeenCalledTimes(2);
+
+      // --- Step 4: resolving the old revoked token A must fail ---
+      (mockPrisma.calendarFeedToken.findUnique as jest.Mock).mockResolvedValue({
+        id: 'token-a-id',
+        userId: user.id,
+        teamId: team.id,
+        token: tokenA,
+        revokedAt: new Date(),
+        createdAt: new Date(),
+      });
+      await expect(
+        CalendarService.resolveToken(team.id, tokenA)
+      ).rejects.toThrow(/revoked/);
+    });
   });
 
   describe('resolveToken', () => {
@@ -226,6 +288,11 @@ describe('CalendarService', () => {
       expect(ics).toContain('STATUS:CANCELLED');
       expect(ics).toContain('STATUS:TENTATIVE'); // SCHEDULED
       expect(ics).toContain('Final score: 95-90');
+
+      // RFC 5545 requires DTSTAMP on every VEVENT. The `ics` library emits
+      // this automatically — this assertion guards against regressions.
+      const dtstampMatches = ics.match(/DTSTAMP:/g) || [];
+      expect(dtstampMatches.length).toBe(eventMatches.length);
     });
 
     it('returns an empty-but-valid calendar when team has no games', async () => {

--- a/backend/tests/setup.ts
+++ b/backend/tests/setup.ts
@@ -146,6 +146,17 @@ export const mockPrisma = {
     delete: jest.fn(),
     count: jest.fn(),
   },
+  calendarFeedToken: {
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    updateMany: jest.fn(),
+    delete: jest.fn(),
+    deleteMany: jest.fn(),
+    count: jest.fn(),
+  },
   $transaction: jest.fn(),
   $disconnect: jest.fn(),
 };


### PR DESCRIPTION
## Summary

Backend-only implementation of a per-team iCalendar feed so parents
and players can subscribe to their team's schedule from Google
Calendar / Apple Calendar / Outlook. Mobile UI is a follow-up.

- New Prisma model `CalendarFeedToken` (`userId`, `teamId`, `token`,
  `revokedAt`, `createdAt`). Tokens are opaque base64url strings
  generated via `crypto.randomBytes(32)`.
- New service `backend/src/services/calendar-service.ts` builds the
  iCalendar document using the `ics` npm package. Events include:
  opponent, start/end time (games default to 2 hours), iCal status
  (`CONFIRMED`/`TENTATIVE`/`CANCELLED`) derived from `GameStatus`,
  final score for `FINISHED` games, and a URL back to the game detail.
- New routes `backend/src/api/teams/calendar.ts`:
  - `GET  /api/v1/teams/:id/calendar.ics?token=...` — public,
    token-auth (calendar clients can't send `Authorization` headers).
  - `POST /api/v1/teams/:id/calendar/subscribe` — authenticated;
    returns `{ token, feedUrl, webcalUrl }`, reusing an existing active
    token if one exists.
  - `POST /api/v1/teams/:id/calendar/revoke` — authenticated;
    invalidates all of the user's tokens for the team.
- Authorization on the `.ics` fetch: token must exist, not be revoked,
  match the URL's `teamId`, and the user must still have access to the
  team (reuses `canAccessTeam` from `utils/permissions`).
- Migration: `20260412200823_add_calendar_feed_token`.

## Test plan

- [x] Unit tests for `CalendarService` (subscribe/revoke/resolveToken/
      buildFeed/generateTokenString) — 16 tests
- [x] API integration tests for all three endpoints — 13 tests
- [x] Covers: valid token, revoked token, wrong-team token, stale
      user-access token, missing token, non-UUID param, empty
      schedule, all four `GameStatus` values
- [x] `npm test` — 633 tests passing (34 existing suites + 2 new)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [ ] Manual: subscribe from Apple Calendar, add a game in-app, wait
      for refresh, confirm it appears (follow-up once mobile UI lands)

## Out of scope (follow-ups)

- Mobile UI: "Subscribe to calendar" button on team detail screen (new
  issue).
- Two-way sync (writing from calendar back to app).
- Practice events — comes with the recurring-events issue.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)