### PR TITLE
feat(backend): Socket.io handlers for live game event broadcast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,26 @@ Backend API (Node.js/Express)
 - **hooks/**: Custom React hooks
 - **i18n/**: Internationalization
 
+### Socket.io (Live Game Broadcast)
+
+Real-time game updates use Socket.io with an in-memory adapter. Single-replica
+only — see `backend/src/index.ts` for the multi-replica startup guard and
+issue #26 for the Redis adapter follow-up.
+
+| Direction       | Event                | Payload                                |
+| --------------- | -------------------- | -------------------------------------- |
+| client → server | `join-game`          | `{ gameId }` (ack with success/error)  |
+| client → server | `leave-game`         | `{ gameId }`                           |
+| server → client | `game-snapshot`      | `{ game, events }` (on join / rejoin)  |
+| server → client | `game-event`         | `GameEvent` (on persist)               |
+| server → client | `game-status-change` | `{ gameId, status }` (on transition)   |
+
+- Handshake auth: bearer token via `socket.handshake.auth.token` (or
+  `Authorization` header). Checked once at connect; see `authenticateSocket`.
+- Room naming: `game:<gameId>` (see `GAME_ROOM_PREFIX` / `gameRoom()`).
+- Snapshot cap: `SNAPSHOT_EVENT_LIMIT = 100` most-recent events returned on
+  join, in chronological order.
+
 ### Key Patterns
 - Layered architecture: API routes → Services → Models (Prisma)
 - Event-driven: Kafka for game events, Flink for real-time aggregation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,76 @@
+# Roadmap
+
+Strategy document for Capy Hoops / Basketball Tracker. Narrative lives here;
+execution lives in GitHub Issues and Milestones. Each phase below maps to a
+milestone; each checklist item maps to an issue.
+
+## Positioning
+
+A hybrid of GameChanger (live stat tracking, box scores) and TeamSnap-lite
+(teams, games, RSVPs, announcements). The app tracks live games *and* manages
+the team around them — most competitors do one or the other well.
+
+**Differentiators**
+- Live in-game stat tracking with a spectator-friendly real-time view
+- Box scores + season stats built in, not a bolt-on
+- COPPA-compliant managed players for youth leagues
+
+**Non-goals (for now)**
+- Full video/clip platform (GameChanger territory)
+- Full league-ops / registration platform (TeamSnap Pro territory) — see v2.2
+- Multi-sport expansion
+
+## Phases
+
+### v2.0 — General Access (GA)
+
+First public release. Open signups to anyone, not just early-access teams.
+
+Focus: close the gaps that block a parent or coach from relying on the app
+day-to-day (email notifications, live spectator view, observability, legal).
+
+Milestone: [`v2.0 GA`](../../milestone/1)
+
+### v2.1 — Parity
+
+Reach feature parity with TeamSnap on the team-management surface so we don't
+lose deals on "does it have an iCal feed?" or "can I export stats?"
+
+Focus: calendar sync, recurring events, photo gallery, stats export, SMS.
+
+Milestone: [`v2.1 Parity`](../../milestone/2)
+
+### v2.2 — Monetization
+
+Turn on revenue. Stripe subscriptions first (Coach Premium, League), then
+Stripe Connect for registration/dues payments (take-rate revenue is where
+TeamSnap makes its money).
+
+Milestone: [`v2.2 Monetization`](../../milestone/3)
+
+## Tier design (target)
+
+| Tier | Price | Audience | Key features |
+|---|---|---|---|
+| Free | $0 | Independent coaches, tryouts | 1 team, full stat tracking, basic schedule, push notifications |
+| Coach Premium | ~$9.99/mo or ~$79/yr | Serious coaches, club teams | Unlimited teams, email/SMS, calendar sync, stats export, photo gallery, ad-free |
+| League | ~$49–99/mo | Multi-team orgs | Everything above + org messaging, tournament brackets, admin dashboards |
+| Registration payments | 2.9% + $0.30 take-rate | Leagues collecting dues | Stripe Connect; highest-ARPU feature |
+
+iOS subscriptions must use Apple IAP (15–30% Apple tax). Web-only upgrade is a
+legitimate workaround under the Epic v. Apple ruling and is worth evaluating.
+
+## Agent execution
+
+Many issues are labelled `agent-ready` — they are scoped, have acceptance
+criteria, file paths, and verification commands, and are safe to hand to an
+unassisted background agent. Issues labelled `needs-human` require credentials,
+design judgment, or product scoping and should not be delegated.
+
+## Version scheme
+
+- Milestone numbers map to git tags. Shipping everything in `v2.0 GA` triggers
+  a `v2.0.0` tag and a GitHub Release.
+- Minor versions (v2.0.1, v2.0.2…) are patch releases within a phase.
+- Major bumps (v2 → v3) are reserved for architectural changes or second public
+  launch moments.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -40,6 +40,7 @@
         "eslint": "^10.1.0",
         "globals": "^17.4.0",
         "jest": "^29.7.0",
+        "socket.io-client": "^4.8.3",
         "supertest": "^7.1.3",
         "ts-jest": "^29.4.6",
         "tsx": "^4.7.0",
@@ -5193,6 +5194,20 @@
         "node": ">=10.2.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -8855,6 +8870,22 @@
         "ws": "~8.18.3"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
@@ -9812,6 +9843,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -64,6 +64,7 @@
     "eslint": "^10.1.0",
     "globals": "^17.4.0",
     "jest": "^29.7.0",
+    "socket.io-client": "^4.8.3",
     "supertest": "^7.1.3",
     "ts-jest": "^29.4.6",
     "tsx": "^4.7.0",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,12 +17,30 @@ const httpServer = createServer(app);
 // Support multiple origins for mobile (Expo) and web
 const corsOrigins = (process.env.CORS_ORIGIN || 'http://localhost:19006').split(',').map(o => o.trim());
 
+// Socket.io currently uses the in-memory adapter. Rooms are local to a single
+// process, so broadcasts do NOT fan out across replicas. The GA target is a
+// single ECS task; horizontal scale requires `@socket.io/redis-adapter`
+// (tracked in issue #26). The startup guard below logs loudly if we boot in
+// production without a Redis adapter URL configured.
 const io = new SocketServer(httpServer, {
   cors: {
     origin: corsOrigins.length === 1 ? corsOrigins[0] : corsOrigins,
     methods: ['GET', 'POST'],
   },
 });
+
+if (
+  process.env.NODE_ENV === 'production' &&
+  !process.env.REDIS_SOCKET_ADAPTER_URL
+) {
+  logger.error(
+    'FATAL-WARN: Socket.io running without Redis adapter in production. ' +
+      'Live game broadcasts will only reach clients connected to the SAME ' +
+      'backend replica. This is safe only when running a SINGLE ECS task. ' +
+      'Set REDIS_SOCKET_ADAPTER_URL and wire up @socket.io/redis-adapter ' +
+      'before scaling >1 replica. (issue #26)'
+  );
+}
 
 const PORT = process.env.PORT || 3000;
 

--- a/backend/src/services/game-event-service.ts
+++ b/backend/src/services/game-event-service.ts
@@ -7,6 +7,7 @@ import { GameEventType, Prisma } from '@prisma/client';
 import { CreateGameEventInput, GameEventQueryParams } from '../api/games/schemas';
 import { NotFoundError, ForbiddenError } from '../utils/errors';
 import { hasTeamPermission, canAccessTeam } from '../utils/permissions';
+import { emitGameEvent } from '../websocket/emit';
 
 export class GameEventService {
   /**
@@ -91,6 +92,13 @@ export class GameEventService {
           },
         },
       },
+    });
+
+    // Broadcast to spectators in the game room. `emitGameEvent` no-ops if
+    // Socket.io isn't initialized (e.g., in tests or CLI scripts).
+    emitGameEvent(gameId, {
+      event,
+      score: { homeScore: game.homeScore, awayScore: game.awayScore },
     });
 
     return event;

--- a/backend/src/services/game-service.ts
+++ b/backend/src/services/game-service.ts
@@ -8,6 +8,7 @@ import { NotFoundError, ForbiddenError } from '../utils/errors';
 import { hasTeamPermission, canAccessTeam, isSystemAdmin } from '../utils/permissions';
 import { StatsService } from './stats-service';
 import { logger } from '../utils/logger';
+import { emitGameStatusChange } from '../websocket/emit';
 
 export class GameService {
   /**
@@ -357,6 +358,21 @@ export class GameService {
         logger.error('Error finalizing game stats', { error: error instanceof Error ? error.message : String(error) });
         // Don't fail the update if stats calculation fails
       }
+    }
+
+    // Broadcast status transition to live spectators. No-ops when Socket.io
+    // isn't initialized. Scores are included so clients can stay in sync even
+    // if they missed the triggering event.
+    if (updateData.status !== undefined && updateData.status !== game.status) {
+      emitGameStatusChange(gameId, {
+        gameId,
+        previousStatus: game.status,
+        status: updatedGame.status,
+        score: {
+          homeScore: updatedGame.homeScore,
+          awayScore: updatedGame.awayScore,
+        },
+      });
     }
 
     return updatedGame;

--- a/backend/src/websocket/emit.ts
+++ b/backend/src/websocket/emit.ts
@@ -1,0 +1,59 @@
+/**
+ * Fire-and-forget emit helpers for game rooms.
+ *
+ * Services call these after persisting a change. The helpers pull the current
+ * Socket.io server from the registry (see `io-registry.ts`) and no-op when no
+ * server has been registered. Errors are logged but never thrown — a broken
+ * real-time broadcast must never cause a write path to fail.
+ */
+
+import type { GameEvent, GameStatus } from '@prisma/client';
+import { getIo } from './io-registry';
+import { gameRoom } from './game-events';
+import { logger } from '../utils/logger';
+
+export interface GameScore {
+  homeScore: number;
+  awayScore: number;
+}
+
+export interface GameEventBroadcast {
+  event: GameEvent & { player?: { id: string; name: string } | null };
+  score: GameScore;
+}
+
+export function emitGameEvent(gameId: string, payload: GameEventBroadcast): void {
+  const io = getIo();
+  if (!io) return;
+  try {
+    io.to(gameRoom(gameId)).emit('game-event', payload);
+  } catch (error) {
+    logger.error('Failed to emit game-event', {
+      gameId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export interface GameStatusChangeBroadcast {
+  gameId: string;
+  previousStatus: GameStatus;
+  status: GameStatus;
+  score: GameScore;
+}
+
+export function emitGameStatusChange(
+  gameId: string,
+  payload: GameStatusChangeBroadcast
+): void {
+  const io = getIo();
+  if (!io) return;
+  try {
+    io.to(gameRoom(gameId)).emit('game-status-change', payload);
+  } catch (error) {
+    logger.error('Failed to emit game-status-change', {
+      gameId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/backend/src/websocket/game-events.ts
+++ b/backend/src/websocket/game-events.ts
@@ -1,0 +1,296 @@
+/**
+ * Socket.io handlers for live game event broadcast.
+ *
+ * Protocol
+ *  - Client authenticates on the handshake by supplying `auth.token` (same
+ *    bearer token used on the REST API — WorkOS access token or dev token).
+ *  - Client emits `join-game` with `{ gameId }`. Server verifies the user can
+ *    view the game using the same rules as `GET /games/:id` (canAccessTeam).
+ *    On success the socket joins room `game:<gameId>` and receives a
+ *    `game-snapshot` event with the current game state + recent events.
+ *  - Client may emit `leave-game` with `{ gameId }` to leave the room.
+ *  - Server broadcasts `game-event` to `game:<gameId>` whenever an event is
+ *    persisted (via `emitGameEvent`).
+ *  - Server broadcasts `game-status-change` to `game:<gameId>` whenever a
+ *    game transitions state (via `emitGameStatusChange`).
+ *  - Socket.io's built-in ping/pong handles heartbeats. Clients that reconnect
+ *    must re-emit `join-game` to resubscribe; they will receive a fresh
+ *    `game-snapshot`.
+ *
+ * Target concurrency
+ *  - 50 concurrent spectators per game on a single ECS task is the GA target.
+ *    For higher fan-out, add the `@socket.io/redis-adapter` (out of scope
+ *    for this change; see issue #26).
+ */
+
+import type { Server as SocketServer, Socket } from 'socket.io';
+import type { GameEvent, GameStatus } from '@prisma/client';
+import prisma from '../models';
+import { canAccessTeam } from '../utils/permissions';
+import { WorkOSService } from '../services/workos-service';
+import { logger } from '../utils/logger';
+
+export const GAME_ROOM_PREFIX = 'game:';
+export const SNAPSHOT_EVENT_LIMIT = 100;
+
+export interface AuthenticatedSocketUser {
+  id: string;
+  email: string | null;
+  name: string;
+  role: string;
+}
+
+/**
+ * Extend the Socket type with the authenticated user we attach during the
+ * handshake middleware. Socket.io exposes arbitrary fields on `socket.data`
+ * without type checking — we use a narrow interface so downstream handlers
+ * don't need to use `any`.
+ */
+export interface GameSocketData {
+  user: AuthenticatedSocketUser;
+}
+
+// We intentionally keep the event-map generics at their default (untyped) and
+// only parameterize `SocketData`. Typing the full event maps provides little
+// value here (event names are string literals at the call site) and would
+// force `socket.emit` to reject dynamic payloads.
+export type GameSocket = Socket & { data: GameSocketData };
+
+export function gameRoom(gameId: string): string {
+  return `${GAME_ROOM_PREFIX}${gameId}`;
+}
+
+/**
+ * Resolve a bearer-style token to a local user. Mirrors the logic in
+ * `src/api/auth/middleware.ts` but returns a plain value instead of mutating
+ * an Express request. Returns `null` when the token is invalid/expired or the
+ * user does not exist.
+ */
+export async function resolveSocketUser(
+  rawToken: string | undefined
+): Promise<AuthenticatedSocketUser | null> {
+  if (!rawToken || typeof rawToken !== 'string') {
+    return null;
+  }
+
+  // Accept both "Bearer <token>" and bare tokens for flexibility in clients.
+  const token = rawToken.startsWith('Bearer ') ? rawToken.substring(7) : rawToken;
+
+  // Dev token path (development only) — matches REST middleware.
+  if (process.env.NODE_ENV === 'development' && token.startsWith('dev_')) {
+    try {
+      const decoded = JSON.parse(
+        Buffer.from(token.substring(4), 'base64').toString()
+      ) as { userId?: string; exp?: number };
+
+      if (!decoded.userId || !decoded.exp || decoded.exp < Date.now()) {
+        return null;
+      }
+
+      const user = await prisma.user.findUnique({
+        where: { id: decoded.userId },
+        select: { id: true, email: true, name: true, role: true },
+      });
+      return user ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  const workosUser = await WorkOSService.verifyToken(token);
+  if (!workosUser) {
+    return null;
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { workosUserId: workosUser.id },
+    select: { id: true, email: true, name: true, role: true },
+  });
+  return user ?? null;
+}
+
+/**
+ * Socket.io connection authentication middleware. Runs once per socket during
+ * the handshake.
+ */
+export async function authenticateSocket(
+  socket: GameSocket,
+  next: (err?: Error) => void
+): Promise<void> {
+  try {
+    const authPayload = socket.handshake.auth as { token?: string } | undefined;
+    const headerToken = socket.handshake.headers.authorization;
+    const token = authPayload?.token ?? headerToken;
+
+    const user = await resolveSocketUser(token);
+    if (!user) {
+      next(new Error('Unauthorized'));
+      return;
+    }
+
+    socket.data.user = user;
+    next();
+  } catch (error) {
+    logger.error('Socket authentication failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    next(new Error('Unauthorized'));
+  }
+}
+
+interface JoinGamePayload {
+  gameId?: unknown;
+}
+
+function extractGameId(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const { gameId } = payload as JoinGamePayload;
+  return typeof gameId === 'string' && gameId.length > 0 ? gameId : null;
+}
+
+/**
+ * Build the snapshot payload returned on join / rejoin. Includes the current
+ * game row and the most recent events so reconnecting clients can rebuild
+ * state without a separate REST call.
+ */
+export interface GameSnapshot {
+  game: {
+    id: string;
+    teamId: string;
+    opponent: string;
+    date: Date;
+    status: GameStatus;
+    homeScore: number;
+    awayScore: number;
+  };
+  events: Array<GameEvent & { player?: { id: string; name: string } | null }>;
+}
+
+export async function buildGameSnapshot(gameId: string): Promise<GameSnapshot | null> {
+  const game = await prisma.game.findUnique({
+    where: { id: gameId },
+    include: {
+      events: {
+        include: {
+          player: { select: { id: true, name: true } },
+        },
+        orderBy: { timestamp: 'desc' },
+        take: SNAPSHOT_EVENT_LIMIT,
+      },
+    },
+  });
+
+  if (!game) return null;
+
+  // Return events in chronological order for client convenience.
+  return {
+    game: {
+      id: game.id,
+      teamId: game.teamId,
+      opponent: game.opponent,
+      date: game.date,
+      status: game.status,
+      homeScore: game.homeScore,
+      awayScore: game.awayScore,
+    },
+    events: [...game.events].reverse(),
+  };
+}
+
+/**
+ * Authorize and join the requesting user into the `game:<gameId>` room.
+ * Exposed separately so unit tests can exercise authorization without wiring
+ * a full Socket.io server.
+ */
+export async function handleJoinGame(
+  socket: GameSocket,
+  payload: unknown
+): Promise<
+  | { ok: true; gameId: string }
+  | { ok: false; code: 'bad_request' | 'not_found' | 'forbidden'; message: string }
+> {
+  const gameId = extractGameId(payload);
+  if (!gameId) {
+    return { ok: false, code: 'bad_request', message: 'gameId is required' };
+  }
+
+  const game = await prisma.game.findUnique({
+    where: { id: gameId },
+    select: { id: true, teamId: true },
+  });
+  if (!game) {
+    return { ok: false, code: 'not_found', message: 'Game not found' };
+  }
+
+  const user = socket.data.user;
+  const hasAccess = await canAccessTeam(user.id, game.teamId);
+  if (!hasAccess) {
+    return { ok: false, code: 'forbidden', message: 'You do not have access to this game' };
+  }
+
+  await socket.join(gameRoom(gameId));
+
+  const snapshot = await buildGameSnapshot(gameId);
+  if (snapshot) {
+    socket.emit('game-snapshot', snapshot);
+  }
+
+  return { ok: true, gameId };
+}
+
+/**
+ * Wire up connection handlers on the provided Socket.io server. Called once
+ * at server startup from `setupWebSocketHandlers`.
+ */
+export function registerGameEventHandlers(io: SocketServer): void {
+  io.use((socket, next) => {
+    void authenticateSocket(socket as GameSocket, next);
+  });
+
+  io.on('connection', (socket: Socket) => {
+    const typedSocket = socket as GameSocket;
+    const userId = typedSocket.data.user?.id;
+    logger.info('Socket connected', { socketId: socket.id, userId });
+
+    socket.on('join-game', (payload: unknown, ack?: (response: unknown) => void) => {
+      void handleJoinGame(typedSocket, payload).then((result) => {
+        if (!result.ok) {
+          logger.warn('Socket join-game rejected', {
+            socketId: socket.id,
+            userId,
+            code: result.code,
+          });
+          if (ack) ack({ success: false, error: result.message, code: result.code });
+          return;
+        }
+        logger.info('Socket joined game room', {
+          socketId: socket.id,
+          userId,
+          gameId: result.gameId,
+        });
+        if (ack) ack({ success: true, gameId: result.gameId });
+      }).catch((error) => {
+        logger.error('Socket join-game error', {
+          socketId: socket.id,
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        if (ack) ack({ success: false, error: 'Internal error', code: 'internal' });
+      });
+    });
+
+    socket.on('leave-game', (payload: unknown, ack?: (response: unknown) => void) => {
+      const gameId = extractGameId(payload);
+      if (!gameId) {
+        if (ack) ack({ success: false, error: 'gameId is required', code: 'bad_request' });
+        return;
+      }
+      void socket.leave(gameRoom(gameId));
+      if (ack) ack({ success: true, gameId });
+    });
+
+    socket.on('disconnect', (reason: string) => {
+      logger.info('Socket disconnected', { socketId: socket.id, userId, reason });
+    });
+  });
+}

--- a/backend/src/websocket/game-events.ts
+++ b/backend/src/websocket/game-events.ts
@@ -112,6 +112,13 @@ export async function resolveSocketUser(
 /**
  * Socket.io connection authentication middleware. Runs once per socket during
  * the handshake.
+ *
+ * JWT TTL expectation: authentication is checked ONLY at handshake time. If
+ * the bearer token expires mid-session, the socket remains connected and
+ * authorized until the client disconnects (network drop, tab close, explicit
+ * `disconnect()`). For spectator sessions (<2hr games) this is acceptable —
+ * WorkOS access tokens live long enough to cover a game. Periodic re-auth on
+ * long-lived sockets is deferred; tracked in issue #49.
  */
 export async function authenticateSocket(
   socket: GameSocket,
@@ -222,6 +229,10 @@ export async function handleJoinGame(
     return { ok: false, code: 'not_found', message: 'Game not found' };
   }
 
+  // All games are currently team-private: only members of the game's team can
+  // spectate via Socket.io. The Game model has no `isPublic`/`visibility`
+  // field yet. Public spectator mode (open join for any authenticated user)
+  // is tracked in issue #48.
   const user = socket.data.user;
   const hasAccess = await canAccessTeam(user.id, game.teamId);
   if (!hasAccess) {

--- a/backend/src/websocket/index.ts
+++ b/backend/src/websocket/index.ts
@@ -3,10 +3,13 @@
  */
 
 import { Server as SocketServer } from 'socket.io';
+import { registerGameEventHandlers } from './game-events';
+import { setIo } from './io-registry';
 
-export function setupWebSocketHandlers(_io: SocketServer): void {
-  // WebSocket event handlers will be implemented here
-  // Example: game updates, real-time statistics, etc.
-  // TODO: Implement WebSocket handlers when real-time features are added
+export function setupWebSocketHandlers(io: SocketServer): void {
+  setIo(io);
+  registerGameEventHandlers(io);
 }
 
+export { getIo, setIo } from './io-registry';
+export { emitGameEvent, emitGameStatusChange } from './emit';

--- a/backend/src/websocket/io-registry.ts
+++ b/backend/src/websocket/io-registry.ts
@@ -1,0 +1,21 @@
+/**
+ * Registry for the Socket.io server instance.
+ *
+ * Services that produce real-time events (e.g., game events, status changes)
+ * import the current server via `getIo()`. The HTTP bootstrap in `src/index.ts`
+ * registers the instance with `setIo()`. Tests can register a test server the
+ * same way. `getIo()` returns `null` when no server has been registered, which
+ * lets service code no-op when running outside the Socket.io-enabled runtime.
+ */
+
+import type { Server as SocketServer } from 'socket.io';
+
+let ioInstance: SocketServer | null = null;
+
+export function setIo(io: SocketServer | null): void {
+  ioInstance = io;
+}
+
+export function getIo(): SocketServer | null {
+  return ioInstance;
+}

--- a/backend/tests/websocket/emit.test.ts
+++ b/backend/tests/websocket/emit.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for the emit helpers — verify that when Socket.io is registered,
+ * helpers target the correct room; and when no server is registered they
+ * silently no-op instead of throwing.
+ */
+
+import { emitGameEvent, emitGameStatusChange } from '../../src/websocket/emit';
+import { setIo } from '../../src/websocket/io-registry';
+import { gameRoom } from '../../src/websocket/game-events';
+import type { Server as SocketServer } from 'socket.io';
+import type { GameEvent, GameStatus } from '@prisma/client';
+
+interface FakeIo {
+  io: SocketServer;
+  emit: jest.Mock;
+  to: jest.Mock;
+}
+
+function makeFakeIo(): FakeIo {
+  const emit = jest.fn();
+  const to = jest.fn().mockReturnValue({ emit });
+  return { io: { to } as unknown as SocketServer, emit, to };
+}
+
+function makeFakeEvent(): GameEvent {
+  return {
+    id: 'evt-1',
+    gameId: 'game-1',
+    playerId: null,
+    eventType: 'SHOT',
+    timestamp: new Date(),
+    metadata: {},
+    createdAt: new Date(),
+  } as unknown as GameEvent;
+}
+
+describe('websocket/emit', () => {
+  afterEach(() => {
+    setIo(null);
+  });
+
+  describe('emitGameEvent', () => {
+    it('no-ops when no Socket.io server is registered', () => {
+      expect(() => emitGameEvent('game-1', {
+        event: makeFakeEvent(),
+        score: { homeScore: 0, awayScore: 0 },
+      })).not.toThrow();
+    });
+
+    it('broadcasts to the game room with the event payload', () => {
+      const { io, to, emit } = makeFakeIo();
+      setIo(io);
+
+      const event = makeFakeEvent();
+      emitGameEvent('game-1', { event, score: { homeScore: 4, awayScore: 2 } });
+
+      expect(to).toHaveBeenCalledWith(gameRoom('game-1'));
+      expect(emit).toHaveBeenCalledWith('game-event', {
+        event,
+        score: { homeScore: 4, awayScore: 2 },
+      });
+    });
+
+    it('swallows errors from the underlying socket server', () => {
+      const to = jest.fn(() => {
+        throw new Error('boom');
+      });
+      setIo({ to } as unknown as SocketServer);
+      expect(() =>
+        emitGameEvent('game-1', {
+          event: makeFakeEvent(),
+          score: { homeScore: 0, awayScore: 0 },
+        })
+      ).not.toThrow();
+    });
+  });
+
+  describe('emitGameStatusChange', () => {
+    it('broadcasts a status-change payload to the game room', () => {
+      const { io, to, emit } = makeFakeIo();
+      setIo(io);
+
+      const payload = {
+        gameId: 'game-1',
+        previousStatus: 'SCHEDULED' as GameStatus,
+        status: 'IN_PROGRESS' as GameStatus,
+        score: { homeScore: 0, awayScore: 0 },
+      };
+      emitGameStatusChange('game-1', payload);
+
+      expect(to).toHaveBeenCalledWith(gameRoom('game-1'));
+      expect(emit).toHaveBeenCalledWith('game-status-change', payload);
+    });
+
+    it('no-ops when no Socket.io server is registered', () => {
+      expect(() =>
+        emitGameStatusChange('game-1', {
+          gameId: 'game-1',
+          previousStatus: 'SCHEDULED',
+          status: 'IN_PROGRESS',
+          score: { homeScore: 0, awayScore: 0 },
+        })
+      ).not.toThrow();
+    });
+  });
+});

--- a/backend/tests/websocket/game-events.integration.test.ts
+++ b/backend/tests/websocket/game-events.integration.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Integration test: connect → join → receive snapshot → receive event.
+ *
+ * Spins up a real Socket.io server bound to an ephemeral port, registers the
+ * production handlers, and uses socket.io-client to drive the full transport
+ * path. Prisma is still mocked via `tests/setup.ts` so we exercise the room
+ * + authorization wiring without a database.
+ */
+
+import { createServer, type Server as HttpServer } from 'http';
+import { AddressInfo } from 'net';
+import { Server as SocketServer } from 'socket.io';
+import { io as ioClient, type Socket as ClientSocket } from 'socket.io-client';
+
+import { setupWebSocketHandlers, emitGameEvent } from '../../src/websocket';
+import { setIo } from '../../src/websocket/io-registry';
+import { mockPrisma } from '../setup';
+import {
+  createCoach,
+  createTeam,
+  createSeason,
+  createLeague,
+  createGame,
+  createGameEvent,
+  createTeamRole,
+  createTeamStaff,
+} from '../factories';
+
+describe('websocket integration (socket.io-client)', () => {
+  let httpServer: HttpServer;
+  let io: SocketServer;
+  let port: number;
+  const originalEnv = process.env.NODE_ENV;
+
+  beforeAll((done) => {
+    process.env.NODE_ENV = 'development';
+    httpServer = createServer();
+    io = new SocketServer(httpServer);
+    setupWebSocketHandlers(io);
+    httpServer.listen(() => {
+      port = (httpServer.address() as AddressInfo).port;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    process.env.NODE_ENV = originalEnv;
+    setIo(null);
+    io.close(() => {
+      httpServer.close(() => done());
+    });
+  });
+
+  function buildDevToken(userId: string): string {
+    const payload = Buffer.from(
+      JSON.stringify({ userId, exp: Date.now() + 60_000 })
+    ).toString('base64');
+    return `dev_${payload}`;
+  }
+
+  function connect(token: string | undefined): ClientSocket {
+    return ioClient(`http://localhost:${port}`, {
+      transports: ['websocket'],
+      forceNew: true,
+      reconnection: false,
+      auth: token ? { token } : {},
+    });
+  }
+
+  it('rejects connections without a valid token', (done) => {
+    const client = connect(undefined);
+    client.on('connect_error', (err) => {
+      expect(err.message).toBe('Unauthorized');
+      client.close();
+      done();
+    });
+  });
+
+  it('allows a coach to join and receive a snapshot + broadcast event', (done) => {
+    const coach = createCoach();
+    const league = createLeague();
+    const season = createSeason({ leagueId: league.id });
+    const team = createTeam({ seasonId: season.id });
+    const role = createTeamRole({ teamId: team.id, type: 'HEAD_COACH' });
+    const staff = createTeamStaff({ teamId: team.id, userId: coach.id, roleId: role.id });
+    const game = createGame({
+      teamId: team.id,
+      status: 'IN_PROGRESS',
+      homeScore: 6,
+      awayScore: 4,
+    });
+    const existingEvent = createGameEvent({ gameId: game.id, eventType: 'SHOT' });
+
+    // Mock resolveSocketUser -> dev token path pulls user by id.
+    (mockPrisma.user.findUnique as jest.Mock).mockImplementation((args: { where: { id?: string } }) => {
+      if (args?.where?.id === coach.id) {
+        return Promise.resolve({
+          id: coach.id,
+          email: coach.email,
+          name: coach.name,
+          role: coach.role,
+        });
+      }
+      return Promise.resolve(coach);
+    });
+
+    // handleJoinGame: findUnique(game) for auth, then for snapshot.
+    (mockPrisma.game.findUnique as jest.Mock)
+      .mockResolvedValueOnce({ id: game.id, teamId: team.id })
+      .mockResolvedValueOnce({
+        ...game,
+        events: [existingEvent],
+      });
+
+    // canAccessTeam: staff check
+    (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue({
+      ...team,
+      season: { ...season, league: { ...league, admins: [] } },
+    });
+    (mockPrisma.teamStaff.findFirst as jest.Mock).mockResolvedValue(staff);
+
+    const client = connect(buildDevToken(coach.id));
+
+    client.on('connect_error', (err) => {
+      client.close();
+      done(err);
+    });
+
+    client.on('connect', () => {
+      client.once('game-snapshot', (snapshot: unknown) => {
+        const snap = snapshot as {
+          game: { id: string; status: string; homeScore: number; awayScore: number };
+          events: Array<{ id: string }>;
+        };
+        expect(snap.game.id).toBe(game.id);
+        expect(snap.game.status).toBe('IN_PROGRESS');
+        expect(snap.events.map((e) => e.id)).toContain(existingEvent.id);
+
+        // After snapshot, simulate a new event being broadcast.
+        client.once('game-event', (payload: unknown) => {
+          const msg = payload as {
+            event: { id: string; eventType: string };
+            score: { homeScore: number; awayScore: number };
+          };
+          expect(msg.event.id).toBe('evt-broadcast');
+          expect(msg.event.eventType).toBe('REBOUND');
+          expect(msg.score).toEqual({ homeScore: 6, awayScore: 4 });
+          client.close();
+          done();
+        });
+
+        // Give the server a tick to finish the join before broadcasting.
+        setTimeout(() => {
+          const broadcastEvent = {
+            id: 'evt-broadcast',
+            gameId: game.id,
+            playerId: null,
+            eventType: 'REBOUND',
+            timestamp: new Date(),
+            metadata: {},
+            createdAt: new Date(),
+          };
+          emitGameEvent(game.id, {
+            event: broadcastEvent as unknown as Parameters<typeof emitGameEvent>[1]['event'],
+            score: { homeScore: 6, awayScore: 4 },
+          });
+        }, 25);
+      });
+
+      client.emit('join-game', { gameId: game.id }, (response: unknown) => {
+        const resp = response as { success: boolean; gameId?: string };
+        expect(resp.success).toBe(true);
+        expect(resp.gameId).toBe(game.id);
+      });
+    });
+  }, 10000);
+});

--- a/backend/tests/websocket/game-events.test.ts
+++ b/backend/tests/websocket/game-events.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for Socket.io game-events authorization + snapshot logic.
+ *
+ * We exercise `handleJoinGame` and `buildGameSnapshot` directly with a
+ * lightweight fake socket — no real Socket.io server is started. The
+ * integration test covers the full transport path.
+ */
+
+import {
+  buildGameSnapshot,
+  handleJoinGame,
+  gameRoom,
+  GAME_ROOM_PREFIX,
+  resolveSocketUser,
+  type GameSocket,
+} from '../../src/websocket/game-events';
+import { mockPrisma } from '../setup';
+import {
+  createGame,
+  createTeam,
+  createSeason,
+  createLeague,
+  createPlayer,
+  createCoach,
+  createTeamMember,
+  createTeamRole,
+  createTeamStaff,
+  createGameEvent,
+} from '../factories';
+
+interface FakeSocket {
+  id: string;
+  joined: string[];
+  emitted: Array<{ event: string; payload: unknown }>;
+  data: { user: { id: string; email: string | null; name: string; role: string } };
+  join: jest.Mock;
+  emit: jest.Mock;
+}
+
+function makeFakeSocket(userId: string): FakeSocket {
+  const joined: string[] = [];
+  const emitted: Array<{ event: string; payload: unknown }> = [];
+  return {
+    id: 'sock-1',
+    joined,
+    emitted,
+    data: { user: { id: userId, email: null, name: 'Tester', role: 'USER' } },
+    join: jest.fn((room: string) => {
+      joined.push(room);
+      return Promise.resolve();
+    }),
+    emit: jest.fn((event: string, payload: unknown) => {
+      emitted.push({ event, payload });
+      return true;
+    }),
+  };
+}
+
+describe('websocket/game-events', () => {
+  describe('gameRoom', () => {
+    it('prefixes the game id with the canonical room prefix', () => {
+      expect(gameRoom('abc')).toBe(`${GAME_ROOM_PREFIX}abc`);
+    });
+  });
+
+  describe('handleJoinGame', () => {
+    it('rejects with bad_request when payload omits gameId', async () => {
+      const socket = makeFakeSocket('user-1');
+      const result = await handleJoinGame(socket as unknown as GameSocket, {});
+      expect(result).toEqual({
+        ok: false,
+        code: 'bad_request',
+        message: 'gameId is required',
+      });
+      expect(socket.join).not.toHaveBeenCalled();
+    });
+
+    it('rejects with not_found when the game does not exist', async () => {
+      (mockPrisma.game.findUnique as jest.Mock).mockResolvedValue(null);
+      const socket = makeFakeSocket('user-1');
+
+      const result = await handleJoinGame(socket as unknown as GameSocket, { gameId: 'nope' });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'not_found',
+        message: 'Game not found',
+      });
+    });
+
+    it('rejects with forbidden when the user cannot access the team', async () => {
+      const outsider = createPlayer();
+      const league = createLeague();
+      const season = createSeason({ leagueId: league.id });
+      const team = createTeam({ seasonId: season.id });
+      const game = createGame({ teamId: team.id });
+
+      (mockPrisma.game.findUnique as jest.Mock).mockResolvedValue({
+        id: game.id,
+        teamId: team.id,
+      });
+      // canAccessTeam: not admin, not staff, not a member
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(outsider);
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue({
+        ...team,
+        season: { ...season, league: { ...league, admins: [] } },
+      });
+      (mockPrisma.teamStaff.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.teamMember.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const socket = makeFakeSocket(outsider.id);
+      const result = await handleJoinGame(socket as unknown as GameSocket, { gameId: game.id });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'forbidden',
+        message: 'You do not have access to this game',
+      });
+      expect(socket.join).not.toHaveBeenCalled();
+    });
+
+    it('joins the game room and emits a snapshot when the user has access', async () => {
+      const coach = createCoach();
+      const league = createLeague();
+      const season = createSeason({ leagueId: league.id });
+      const team = createTeam({ seasonId: season.id });
+      const headCoachRole = createTeamRole({ teamId: team.id, type: 'HEAD_COACH' });
+      const coachStaff = createTeamStaff({
+        teamId: team.id,
+        userId: coach.id,
+        roleId: headCoachRole.id,
+      });
+      const player = createPlayer();
+      createTeamMember({ teamId: team.id, playerId: player.id });
+      const game = createGame({
+        teamId: team.id,
+        status: 'IN_PROGRESS',
+        homeScore: 12,
+        awayScore: 9,
+      });
+      const event = createGameEvent({
+        gameId: game.id,
+        playerId: player.id,
+        eventType: 'SHOT',
+      });
+
+      // handleJoinGame does two prisma.game.findUnique calls:
+      //  1) select { id, teamId } for authorization
+      //  2) include events for the snapshot
+      (mockPrisma.game.findUnique as jest.Mock)
+        .mockResolvedValueOnce({ id: game.id, teamId: team.id })
+        .mockResolvedValueOnce({
+          ...game,
+          events: [{ ...event, player: { id: player.id, name: player.name } }],
+        });
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(coach);
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue({
+        ...team,
+        season: { ...season, league: { ...league, admins: [] } },
+      });
+      (mockPrisma.teamStaff.findFirst as jest.Mock).mockResolvedValue(coachStaff);
+
+      const socket = makeFakeSocket(coach.id);
+      const result = await handleJoinGame(socket as unknown as GameSocket, { gameId: game.id });
+
+      expect(result).toEqual({ ok: true, gameId: game.id });
+      expect(socket.join).toHaveBeenCalledWith(gameRoom(game.id));
+      expect(socket.emitted).toHaveLength(1);
+      expect(socket.emitted[0].event).toBe('game-snapshot');
+      const payload = socket.emitted[0].payload as {
+        game: { id: string; status: string; homeScore: number; awayScore: number };
+        events: Array<{ id: string }>;
+      };
+      expect(payload.game.id).toBe(game.id);
+      expect(payload.game.status).toBe('IN_PROGRESS');
+      expect(payload.game.homeScore).toBe(12);
+      expect(payload.events).toHaveLength(1);
+    });
+  });
+
+  describe('buildGameSnapshot', () => {
+    it('returns null when the game does not exist', async () => {
+      (mockPrisma.game.findUnique as jest.Mock).mockResolvedValue(null);
+      const snapshot = await buildGameSnapshot('missing');
+      expect(snapshot).toBeNull();
+    });
+
+    it('returns events in chronological order', async () => {
+      const game = createGame();
+      const older = createGameEvent({ gameId: game.id, eventType: 'SHOT' });
+      const newer = createGameEvent({ gameId: game.id, eventType: 'REBOUND' });
+      // Prisma returns desc (newest first); buildGameSnapshot reverses.
+      (mockPrisma.game.findUnique as jest.Mock).mockResolvedValue({
+        ...game,
+        events: [newer, older],
+      });
+
+      const snapshot = await buildGameSnapshot(game.id);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot?.events.map((e) => e.id)).toEqual([older.id, newer.id]);
+    });
+  });
+
+  describe('resolveSocketUser', () => {
+    it('returns null when the token is missing', async () => {
+      expect(await resolveSocketUser(undefined)).toBeNull();
+      expect(await resolveSocketUser('')).toBeNull();
+    });
+
+    it('returns null when a dev token is expired', async () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      try {
+        const expired = Buffer.from(
+          JSON.stringify({ userId: 'u1', exp: Date.now() - 1000 })
+        ).toString('base64');
+        expect(await resolveSocketUser(`dev_${expired}`)).toBeNull();
+      } finally {
+        process.env.NODE_ENV = originalEnv;
+      }
+    });
+
+    it('resolves a valid dev token to the corresponding user', async () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      try {
+        const user = createCoach();
+        const valid = Buffer.from(
+          JSON.stringify({ userId: user.id, exp: Date.now() + 60_000 })
+        ).toString('base64');
+        (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue({
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          role: user.role,
+        });
+
+        const resolved = await resolveSocketUser(`Bearer dev_${valid}`);
+        expect(resolved).toEqual({
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          role: user.role,
+        });
+      } finally {
+        process.env.NODE_ENV = originalEnv;
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Socket.io handlers for live game broadcast as described in issue #26. The existing server scaffold in `backend/src/websocket/` is fleshed out into per-game rooms (`game:<gameId>`), an authenticated join flow that reuses the REST bearer-token path, and broadcast hooks on the services that already persist game state.

### What shipped

- `backend/src/websocket/game-events.ts` — handshake auth middleware, `join-game` / `leave-game` handlers, `game-snapshot` on (re)join, room membership, structured JSON logging via the existing Datadog logger.
- `backend/src/websocket/emit.ts` — `emitGameEvent` / `emitGameStatusChange` helpers. No-op when no Socket.io server is registered, never throw.
- `backend/src/websocket/io-registry.ts` — tiny `getIo`/`setIo` registry so service code doesn't need to import the HTTP bootstrap.
- `GameEventService.createEvent` — broadcasts `game-event` with the new event + current score after persistence.
- `GameService.updateGame` — broadcasts `game-status-change` on SCHEDULED → IN_PROGRESS → FINISHED transitions.
- `socket.io-client` added as a devDependency for the integration test.

### Protocol

| Event                  | Direction       | Payload                                                                 |
| ---------------------- | --------------- | ----------------------------------------------------------------------- |
| `join-game`            | client → server | `{ gameId }` (acked with `{ success, gameId? , error? , code? }`)       |
| `leave-game`           | client → server | `{ gameId }`                                                            |
| `game-snapshot`        | server → client | `{ game, events[] }` (chronological, up to 100 most recent events)      |
| `game-event`           | server → client | `{ event, score: { homeScore, awayScore } }`                            |
| `game-status-change`   | server → client | `{ gameId, previousStatus, status, score }`                             |

Handshake auth expects `auth.token` (preferred) or the `Authorization` header. Both bare tokens and `Bearer <token>` are accepted. Socket.io's built-in ping/pong covers heartbeat; reconnecting clients re-emit `join-game` to resubscribe and receive a fresh snapshot.

### Concurrency target

50 concurrent spectators per game on a single ECS task is the GA target. Horizontal scaling via `@socket.io/redis-adapter` is explicitly out of scope and documented inline as future work.

## Test plan

- [x] `cd backend && npm test` — 621 passed, 37 suites
- [x] `cd backend && npx tsc --noEmit` — clean
- [x] `cd backend && npm run lint` — 0 errors (225 pre-existing warnings, none introduced by this change)
- [x] Unit tests cover room auth (bad_request / not_found / forbidden / ok) and snapshot ordering
- [x] Unit tests cover emit helpers (no-op without registry, broadcast targets correct room, errors swallowed)
- [x] Integration test with `socket.io-client`: rejects unauthenticated handshakes, authenticated client joins room, receives snapshot, receives subsequent broadcast

## Out of scope

- Mobile spectator UI (tracked separately per issue #26 context)
- Redis adapter for multi-task fan-out
- Video / clip streaming

Closes #26