### PR TITLE
ci: enforce Jest coverage thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,12 +89,12 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/bball_tracker_test
         run: npx prisma migrate deploy
       
-      - name: Run tests
+      - name: Run tests (with coverage gate)
         working-directory: backend
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/bball_tracker_test
           NODE_ENV: test
-        run: npm test
+        run: npm test -- --coverage
 
   test-mobile:
     name: Test Mobile
@@ -114,9 +114,9 @@ jobs:
         working-directory: mobile
         run: npm ci
 
-      - name: Run tests
+      - name: Run tests (with coverage gate)
         working-directory: mobile
-        run: npm test
+        run: npm test -- --coverage
 
       - name: Verify Metro bundle resolves
         working-directory: mobile

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -17,19 +17,24 @@ module.exports = {
     '!src/flink/**',
     '!src/websocket/**',
   ],
-  // Coverage thresholds
+  // Coverage thresholds — floors, not aspirations. CI enforces these via
+  // `npm test -- --coverage`. Ratchet upward over time; never lower.
+  // Current snapshot (2026-04-12): global stmts 75.55 / branches 55.74 /
+  // lines 75.73 / functions 79.13; services stmts 67.38 / branches 54.45 /
+  // lines 67.65 / functions 69.84. Thresholds set ~1pt below for cushion.
+  // Ratchet tracking: issue #51.
   coverageThreshold: {
     global: {
-      branches: 70,
-      functions: 80,
-      lines: 80,
-      statements: 80,
+      branches: 54,
+      functions: 78,
+      lines: 74,
+      statements: 74,
     },
     './src/services/': {
-      branches: 75,
-      functions: 85,
-      lines: 85,
-      statements: 85,
+      branches: 53,
+      functions: 68,
+      lines: 66,
+      statements: 66,
     },
   },
   moduleNameMapper: {

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -17,12 +17,17 @@ module.exports = {
     '!**/*.d.ts',
     '!**/index.ts',
   ],
+  // Coverage thresholds — floors, not aspirations. CI enforces via
+  // `npm test -- --coverage`. Current mobile coverage is very low
+  // (stmts 10.42 / branches 18.75 / lines 10.88 / functions 9.26 as of
+  // 2026-04-12); thresholds set ~1pt below. These should ratchet up
+  // aggressively before GA — see issue #51.
   coverageThreshold: {
     global: {
-      branches: 60,
-      functions: 70,
-      lines: 70,
-      statements: 70,
+      branches: 17,
+      functions: 8,
+      lines: 9,
+      statements: 9,
     },
   },
   moduleNameMapper: {


### PR DESCRIPTION
## Summary

Pass `--coverage` to jest in the `Test Backend` and `Test Mobile` CI jobs so the thresholds declared in `jest.config.js` actually gate merges. Lower declared thresholds to match the repo's current coverage (+~1pt cushion) so existing code passes; ratchet upward via #51.

### Before

- `backend/jest.config.js` declared global 70/80/80/80 and services 75/85/85/85
- `mobile/jest.config.js` declared global 60/70/70/70
- CI ran `npm test` without `--coverage`, so thresholds were never evaluated and had been decorative for months

### After

- Floors set to the actual numbers as of 2026-04-12, minus ~1pt cushion:
  - Backend global: stmts 74 / branches 54 / funcs 78 / lines 74
  - Backend services: stmts 66 / branches 53 / funcs 68 / lines 66
  - Mobile global: stmts 9 / branches 17 / funcs 8 / lines 9
- `npm test -- --coverage` runs in CI → any PR that drops coverage below the floor fails the test job
- Ratchet upward toward the original aspirations tracked in #51

## Test plan

- [x] `cd backend && npm test -- --coverage` — 692 tests pass, no threshold warnings
- [x] `cd mobile && npm test -- --coverage` — 186 tests pass, no threshold warnings
- [ ] CI run confirms Test Backend + Test Mobile jobs still green

Closes nothing directly; addresses ratchet in #51.