### PR TITLE
infra: Terraform-managed Sentry DSN secret + IAM permission

### DIFF
--- a/backend/src/utils/sentry.ts
+++ b/backend/src/utils/sentry.ts
@@ -104,12 +104,15 @@ export function beforeSend(event: Event, _hint?: EventHint): Event {
 
 /**
  * Initialize Sentry. Safe to call multiple times — subsequent calls are no-ops.
- * No-op when `SENTRY_DSN` is unset (dev, tests).
+ * No-op when `SENTRY_DSN` is unset (dev, tests) or set to the literal
+ * sentinel `"disabled"` (production before a real DSN is provisioned).
+ * The sentinel exists because AWS Secrets Manager rejects empty strings,
+ * so the Terraform-managed secret holds "disabled" until the var is set.
  */
 export function initSentry(): void {
   if (initialized) return;
   const dsn = process.env.SENTRY_DSN;
-  if (!dsn) return;
+  if (!dsn || dsn === 'disabled') return;
 
   Sentry.init({
     dsn,

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -75,6 +75,7 @@ resource "aws_iam_role_policy" "ecs_execution_secrets" {
         aws_secretsmanager_secret.jwt_secret.arn,
         aws_secretsmanager_secret.workos_api_key.arn,
         aws_secretsmanager_secret.workos_client_id.arn,
+        aws_secretsmanager_secret.sentry_dsn.arn,
       ]
     }]
   })
@@ -124,6 +125,21 @@ resource "aws_secretsmanager_secret_version" "workos_client_id" {
   count         = var.workos_client_id != "" ? 1 : 0
   secret_id     = aws_secretsmanager_secret.workos_client_id.id
   secret_string = var.workos_client_id
+}
+
+resource "aws_secretsmanager_secret" "sentry_dsn" {
+  name = "${local.name_prefix}/sentry-dsn"
+  tags = { Name = "${local.name_prefix}-sentry-dsn" }
+}
+
+# Always write a version so ECS GetSecretValue always succeeds. When no DSN
+# is provided, use a literal "disabled" sentinel — Sentry's init is tolerant
+# of non-URL strings (logs a warning, sends no events). Flip var.sentry_dsn
+# to a real DSN later and terraform apply rotates the value with no downtime.
+# (AWS Secrets Manager rejects empty strings, so we can't store "" directly.)
+resource "aws_secretsmanager_secret_version" "sentry_dsn" {
+  secret_id     = aws_secretsmanager_secret.sentry_dsn.id
+  secret_string = var.sentry_dsn != "" ? var.sentry_dsn : "disabled"
 }
 
 # Task role - used by the application container itself

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -75,6 +75,11 @@ output "ecs_task_definition_family" {
   value       = aws_ecs_task_definition.app.family
 }
 
+output "sentry_dsn_secret_arn" {
+  description = "Full ARN of the Sentry DSN secret (used in infra/task-definition.json)"
+  value       = aws_secretsmanager_secret.sentry_dsn.arn
+}
+
 # =============================================================================
 # Database
 # =============================================================================

--- a/infra/task-definition.json
+++ b/infra/task-definition.json
@@ -32,7 +32,7 @@
         { "name": "JWT_SECRET", "valueFrom": "arn:aws:secretsmanager:us-east-1:982343512143:secret:bball-tracker-production/jwt-secret-kbvWdL" },
         { "name": "WORKOS_API_KEY", "valueFrom": "arn:aws:secretsmanager:us-east-1:982343512143:secret:bball-tracker-production/workos-api-key-AObTBz" },
         { "name": "WORKOS_CLIENT_ID", "valueFrom": "arn:aws:secretsmanager:us-east-1:982343512143:secret:bball-tracker-production/workos-client-id-LdHfAM" },
-        { "name": "SENTRY_DSN", "valueFrom": "arn:aws:secretsmanager:us-east-1:982343512143:secret:bball-tracker-production/sentry-dsn" }
+        { "name": "SENTRY_DSN", "valueFrom": "arn:aws:secretsmanager:us-east-1:982343512143:secret:bball-tracker-production/sentry-dsn-mC51Yd" }
       ],
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -126,6 +126,13 @@ variable "workos_client_id" {
   default     = ""
 }
 
+variable "sentry_dsn" {
+  description = "Sentry DSN for backend error tracking. Leave empty to disable Sentry (init no-ops)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 # Domain
 variable "domain_name" {
   description = "Root domain name (e.g., capyhoops.com). The API will be served at api.<domain_name>."


### PR DESCRIPTION
## Why

PR #47 merged `SENTRY_DSN` into `infra/task-definition.json` as an ECS secret reference, but the secret was never created in AWS and the ECS execution role had no permission to read it. Since the merge, every ECS deploy fails with:

```
AccessDeniedException: ... not authorized to perform: secretsmanager:GetSecretValue
on resource: arn:aws:secretsmanager:us-east-1:982343512143:secret:bball-tracker-production/sentry-dsn
```

Prod traffic is still served by the previous stable task def (revision 48), but CI on main has been red for every push since #47.

## What this does

Mirrors the existing WorkOS secret pattern in `infra/ecs.tf`:

- New `aws_secretsmanager_secret.sentry_dsn` + secret version
- Version is **always written** (AWS rejects empty `secret_string`, min length 1). When `var.sentry_dsn` is empty it writes the literal sentinel `"disabled"`.
- `aws_iam_role_policy.ecs_execution_secrets` adds the new ARN to the allow-list
- New `var.sentry_dsn` (sensitive, optional, defaults to `""`)
- New `output.sentry_dsn_secret_arn` so the random-suffix ARN can be pasted into `task-definition.json` after apply
- `backend/src/utils/sentry.ts` treats the `"disabled"` sentinel identically to an unset DSN (returns early before `Sentry.init`)

## Deploy steps (for you)

1. `cd infra && terraform apply`
   - With `var.sentry_dsn = ""` (the default), the secret is created with value `"disabled"`.
   - When you have a real DSN, set `sentry_dsn = "https://..."` in `terraform.tfvars` and re-apply; rotates the value with no downtime.
2. `terraform output sentry_dsn_secret_arn` → paste the full ARN (with `-xxxxxx` suffix) into `infra/task-definition.json`, replacing the current short ARN on line 35. I'll ship that as a follow-up commit on this branch once you've shared the output.
3. Merge → CI deploys clean.

## Test plan

- [x] `npm test tests/utils/sentry.test.ts` — 4 scrubber tests still pass
- [x] `npx tsc --noEmit` clean
- [ ] `terraform plan` shows: +1 secret, +1 secret version, modified IAM policy, no other drift (needs your local tf apply to confirm)
- [ ] Post-merge ECS deploy succeeds

## Follow-ups

- #53 — reconcile `ecs.tf` inline task def vs `task-definition.json` split-brain (not addressed here)