### PR TITLE
chore: gitignore terraform.tfvars + local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,15 @@ build/
 .env.test.local
 .env.production.local
 
+# Terraform
+infra/terraform.tfvars
+infra/*.auto.tfvars
+infra/.terraform/
+infra/.terraform.lock.hcl
+infra/terraform.tfstate
+infra/terraform.tfstate.backup
+infra/.terraform.tfstate.lock.info
+
 # IDE
 .vscode/
 .idea/


### PR DESCRIPTION
Belt-and-suspenders for infra secrets. The `infra/terraform.tfvars.example` banner says not to commit `terraform.tfvars`, but the root `.gitignore` never enforced that. Adds the file plus `.terraform/` state artifacts.