### PR TITLE
fix(ci): use modern @sentry/cli sourcemaps upload syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
           npx prisma generate
           npm run build
           npx @sentry/cli releases new "$SENTRY_RELEASE"
-          npx @sentry/cli releases files "$SENTRY_RELEASE" upload-sourcemaps ./dist --rewrite
+          npx @sentry/cli sourcemaps upload --release "$SENTRY_RELEASE" ./dist
           npx @sentry/cli releases finalize "$SENTRY_RELEASE"
 
       - name: Deploy to Amazon ECS


### PR DESCRIPTION
@sentry/cli v2 replaced the old `releases files <rel> upload-sourcemaps <path>` form with `sourcemaps upload --release <rel> <path>`. The old form fails with `unrecognized subcommand 'files'`.

This started breaking on PR #55's main deploy (the first run after `SENTRY_AUTH_TOKEN` was set in GitHub Actions secrets). Previous deploys skipped the step because the env was empty.

**Important:** the ECS deploy itself succeeded — Sentry event capture is live on the backend. Stack traces will just be unmapped (showing compiled `dist/*` paths) until this lands.