### PR TITLE
test(smoke): temporary /__sentry_test route

### DIFF
--- a/backend/src/api/__sentry_test.ts
+++ b/backend/src/api/__sentry_test.ts
@@ -1,0 +1,25 @@
+/**
+ * Temporary smoke-test route for verifying Sentry end-to-end.
+ *
+ * Hit it with a valid JWT:
+ *   curl -H "Authorization: Bearer <jwt>" https://api.capyhoops.com/api/v1/__sentry_test
+ *
+ * Should return 500 and produce a Sentry event with:
+ * - message "sentry smoke test — ignore me"
+ * - release tag = git SHA
+ * - user.id tag populated
+ * - Authorization header scrubbed to [scrubbed]
+ *
+ * REMOVE THIS FILE once Sentry is confirmed live. Tracked informally;
+ * the commit that adds it should be reverted once the smoke test passes.
+ */
+import { Router } from 'express';
+import { authenticate } from './auth/middleware';
+
+const router = Router();
+
+router.get('/__sentry_test', authenticate, () => {
+  throw new Error('sentry smoke test — ignore me');
+});
+
+export default router;

--- a/backend/src/api/index.ts
+++ b/backend/src/api/index.ts
@@ -9,6 +9,7 @@ import playerRoutes from './players/routes';
 import invitationRoutes from './invitations/routes';
 import statsRoutes from './stats/routes';
 import uploadRoutes from './uploads/routes';
+import sentryTestRoutes from './__sentry_test';
 
 const router = Router();
 
@@ -26,6 +27,7 @@ router.use('/players', playerRoutes);
 router.use('/invitations', invitationRoutes);
 router.use('/stats', statsRoutes);
 router.use('/uploads', uploadRoutes);
+router.use('/', sentryTestRoutes);
 
 router.get('/', (_req, res) => {
   res.json({ message: 'API v1' });


### PR DESCRIPTION
Temporary route to smoke-test Sentry end-to-end. Throws an unhandled error; should return 500 and produce a Sentry event with release tag, user.id, and scrubbed Authorization header.

## How to use

After merge + deploy:
\`\`\`bash
curl -H "Authorization: Bearer <your-jwt>" https://api.capyhoops.com/api/v1/__sentry_test
# → 500 response
\`\`\`

Then check the \`bball-tracker-backend\` Sentry project — event should appear within ~30s.

## Verify

- [ ] Event shows in Sentry with message "sentry smoke test — ignore me"
- [ ] Release tag = git SHA of the merge commit
- [ ] user.id tag populated (JWT user)
- [ ] \`request.headers.Authorization\` shows \`[scrubbed]\`
- [ ] Stack trace maps to source paths (not \`dist/\`) — confirms #56 sourcemap upload worked

## Revert

Once verified, revert this commit:
\`\`\`bash
git revert <merge-sha>
\`\`\`