### PR TITLE
fix(mobile): Sentry sourcemap script — trim token + modern @sentry/cli syntax

### DIFF
--- a/mobile/scripts/sentry-upload-sourcemaps.js
+++ b/mobile/scripts/sentry-upload-sourcemaps.js
@@ -29,10 +29,27 @@ function run(cmd, args, opts = {}) {
 }
 
 function main() {
-  if (!process.env.SENTRY_AUTH_TOKEN) {
+  const rawToken = process.env.SENTRY_AUTH_TOKEN;
+  if (!rawToken) {
     console.log('[sentry] SENTRY_AUTH_TOKEN not set; skipping sourcemap upload.');
     return;
   }
+
+  // Strip whitespace — common paste error when setting EAS env vars.
+  // Sentry API rejects tokens containing spaces/newlines with
+  // "Invalid token header" (HTTP 401).
+  const token = rawToken.trim();
+  if (token !== rawToken) {
+    console.warn(
+      '[sentry] SENTRY_AUTH_TOKEN had leading/trailing whitespace; stripped. ' +
+        'Re-set the env var with a clean value to silence this warning.'
+    );
+  }
+  if (!token) {
+    console.error('[sentry] SENTRY_AUTH_TOKEN is whitespace-only; cannot upload.');
+    process.exit(1);
+  }
+  process.env.SENTRY_AUTH_TOKEN = token;
 
   const release =
     process.env.SENTRY_RELEASE ||
@@ -51,15 +68,9 @@ function main() {
 
   console.log(`[sentry] Uploading sourcemaps for release ${release}`);
   run('npx', ['@sentry/cli', 'releases', 'new', release]);
-  run('npx', [
-    '@sentry/cli',
-    'releases',
-    'files',
-    release,
-    'upload-sourcemaps',
-    distDir,
-    '--rewrite',
-  ]);
+  // @sentry/cli v2 replaced "releases files <rel> upload-sourcemaps <dir>"
+  // with "sourcemaps upload --release <rel> <dir>".
+  run('npx', ['@sentry/cli', 'sourcemaps', 'upload', '--release', release, distDir]);
   run('npx', ['@sentry/cli', 'releases', 'finalize', release]);
   console.log('[sentry] Sourcemap upload complete.');
 }


### PR DESCRIPTION
Last iOS production build (cfe53ec0-b0b8-4195-a06f-cbf7c711eab2) failed in the `eas-build-on-success` hook with:

\`\`\`
sentry reported an error: Invalid token header.
Token string should not contain spaces. (http status: 401)
\`\`\`

Two separate bugs in \`mobile/scripts/sentry-upload-sourcemaps.js\`:

1. **Whitespace in \`SENTRY_AUTH_TOKEN\`** — the EAS env var had trailing whitespace from paste. Script now trims + warns.
2. **Stale @sentry/cli syntax** (same issue as #56 on backend) — `releases files ... upload-sourcemaps ...` was replaced with `sourcemaps upload --release ... <dir>` in @sentry/cli v2.

The token-whitespace fix makes the script surface the issue fast. The user still needs to re-set the EAS env var with a clean value to avoid the warning; this PR just makes the failure mode non-destructive.

After merging, trigger a new production EAS build.