### PR TITLE
test(backend): raise services coverage from 75% to 81% (#51)

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -19,24 +19,24 @@ module.exports = {
   ],
   // Coverage thresholds — floors, not aspirations. CI enforces these via
   // `npm test -- --coverage`. Ratchet upward over time; never lower.
-  // Current snapshot (2026-04-13): global stmts 79.70 / branches 59.49 /
-  // lines 79.99 / functions 83.09; services stmts 75.34 / branches 61.78 /
-  // lines 75.82 / functions 78.57. Thresholds set ~1pt below for cushion.
-  // Note: Jest's threshold-global branches computes to ~57.19 on CI (differs
-  // from the istanbul "All files" summary — known quirk). Branches floor is
-  // calibrated to CI's computed value, not the summary. Ratchet tracking: #51.
+  // Current snapshot (2026-04-13, pass 2): global stmts 82.82 / branches 62.20 /
+  // lines 83.05 / functions 87.41; services stmts 81.36 / branches 67.19 /
+  // lines 81.76 / functions 88.09. Thresholds set ~1-2pt below for cushion.
+  // Note: Jest's threshold-global branches computes lower than the istanbul
+  // "All files" summary on CI (known quirk). Branches floor is calibrated
+  // conservatively against the summary. Ratchet tracking: #51.
   coverageThreshold: {
     global: {
-      branches: 56,
-      functions: 82,
-      lines: 79,
-      statements: 79,
+      branches: 57,
+      functions: 86,
+      lines: 82,
+      statements: 82,
     },
     './src/services/': {
-      branches: 60,
-      functions: 77,
-      lines: 74,
-      statements: 74,
+      branches: 65,
+      functions: 86,
+      lines: 80,
+      statements: 80,
     },
   },
   moduleNameMapper: {

--- a/backend/tests/services/notification-service.test.ts
+++ b/backend/tests/services/notification-service.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for NotificationService
+ *
+ * Covers token registration/removal, user-targeted sends, team-targeted sends
+ * (with member+staff fan-out and exclusion), empty-audience short-circuits,
+ * and error swallowing in the Expo send loop.
+ *
+ * The `expo-server-sdk` module is mocked via `moduleNameMapper` in
+ * `jest.config.js` → `tests/__mocks__/expo-server-sdk.js`. The mock's
+ * `Expo.isExpoPushToken` returns true for strings starting with
+ * `ExponentPushToken[`.
+ */
+
+import { Expo } from 'expo-server-sdk';
+import { NotificationService } from '../../src/services/notification-service';
+import { mockPrisma } from '../setup';
+
+type ExpoProto = {
+  sendPushNotificationsAsync: (m: unknown[]) => Promise<unknown[]>;
+};
+const ExpoProto = (Expo as unknown as { prototype: ExpoProto }).prototype;
+
+const VALID_TOKEN = 'ExponentPushToken[abc123]';
+const VALID_TOKEN_2 = 'ExponentPushToken[def456]';
+const INVALID_TOKEN = 'not-a-real-token';
+
+describe('NotificationService', () => {
+  describe('registerToken', () => {
+    it('rejects an invalid Expo push token without touching the DB', async () => {
+      await expect(
+        NotificationService.registerToken('user-1', INVALID_TOKEN, 'ios')
+      ).rejects.toThrow('Invalid Expo push token');
+      expect(mockPrisma.pushToken.upsert).not.toHaveBeenCalled();
+    });
+
+    it('upserts a valid token keyed by token string with platform + userId', async () => {
+      (mockPrisma.pushToken.upsert as jest.Mock).mockResolvedValue({
+        id: 'pt-1',
+        userId: 'user-1',
+        token: VALID_TOKEN,
+        platform: 'ios',
+      });
+
+      const result = await NotificationService.registerToken('user-1', VALID_TOKEN, 'ios');
+
+      expect(mockPrisma.pushToken.upsert).toHaveBeenCalledWith({
+        where: { token: VALID_TOKEN },
+        create: { userId: 'user-1', token: VALID_TOKEN, platform: 'ios' },
+        update: { userId: 'user-1', platform: 'ios' },
+      });
+      expect(result).toEqual(
+        expect.objectContaining({ token: VALID_TOKEN, platform: 'ios' })
+      );
+    });
+  });
+
+  describe('removeToken', () => {
+    it('deletes matching tokens via deleteMany', async () => {
+      (mockPrisma.pushToken.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      const result = await NotificationService.removeToken(VALID_TOKEN);
+
+      expect(mockPrisma.pushToken.deleteMany).toHaveBeenCalledWith({
+        where: { token: VALID_TOKEN },
+      });
+      expect(result).toEqual({ count: 1 });
+    });
+  });
+
+  describe('sendToUsers', () => {
+    it('returns [] and skips Expo calls when no tokens exist for the given users', async () => {
+      (mockPrisma.pushToken.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await NotificationService.sendToUsers(['user-1', 'user-2'], {
+        title: 'Hi',
+        body: 'Hello',
+      });
+
+      expect(result).toEqual([]);
+      expect(mockPrisma.pushToken.findMany).toHaveBeenCalledWith({
+        where: { userId: { in: ['user-1', 'user-2'] } },
+        select: { token: true },
+      });
+    });
+
+    it('builds one Expo message per token and returns a ticket per message', async () => {
+      (mockPrisma.pushToken.findMany as jest.Mock).mockResolvedValue([
+        { token: VALID_TOKEN },
+        { token: VALID_TOKEN_2 },
+      ]);
+
+      const tickets = await NotificationService.sendToUsers(['user-1'], {
+        title: 'Game starting',
+        body: 'Tip-off in 10 minutes',
+        data: { gameId: 'g-1' },
+      });
+
+      // Mock's sendPushNotificationsAsync returns one ticket per message.
+      expect(tickets).toHaveLength(2);
+      expect(tickets.every(t => 'status' in t && t.status === 'ok')).toBe(true);
+    });
+
+    it('defaults data to an empty object and uses sound "default" in the Expo payload', async () => {
+      (mockPrisma.pushToken.findMany as jest.Mock).mockResolvedValue([
+        { token: VALID_TOKEN },
+      ]);
+
+      const original = ExpoProto.sendPushNotificationsAsync;
+      const captured: unknown[][] = [];
+      ExpoProto.sendPushNotificationsAsync = async function (
+        messages: unknown[]
+      ): Promise<unknown[]> {
+        captured.push(messages);
+        return messages.map(() => ({ status: 'ok', id: 'r-1' }));
+      };
+
+      try {
+        await NotificationService.sendToUsers(['user-1'], { title: 't', body: 'b' });
+      } finally {
+        ExpoProto.sendPushNotificationsAsync = original;
+      }
+
+      expect(captured).toHaveLength(1);
+      const sentMessages = captured[0] as Array<{
+        to: string;
+        title: string;
+        body: string;
+        data: Record<string, unknown>;
+        sound: string;
+      }>;
+      expect(sentMessages).toHaveLength(1);
+      expect(sentMessages[0]).toMatchObject({
+        to: VALID_TOKEN,
+        title: 't',
+        body: 'b',
+        data: {},
+        sound: 'default',
+      });
+    });
+
+    it('swallows Expo errors per chunk and continues (logs but does not throw)', async () => {
+      (mockPrisma.pushToken.findMany as jest.Mock).mockResolvedValue([
+        { token: VALID_TOKEN },
+      ]);
+
+      const original = ExpoProto.sendPushNotificationsAsync;
+      let callCount = 0;
+      ExpoProto.sendPushNotificationsAsync = async function (): Promise<unknown[]> {
+        callCount += 1;
+        throw new Error('Expo down');
+      };
+
+      let result: unknown[];
+      try {
+        result = await NotificationService.sendToUsers(['user-1'], {
+          title: 't',
+          body: 'b',
+        });
+      } finally {
+        ExpoProto.sendPushNotificationsAsync = original;
+      }
+
+      expect(result).toEqual([]);
+      expect(callCount).toBe(1);
+    });
+  });
+
+  describe('sendToTeam', () => {
+    it('returns [] when the team has no members and no staff', async () => {
+      (mockPrisma.teamMember.findMany as jest.Mock).mockResolvedValue([]);
+      (mockPrisma.teamStaff.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await NotificationService.sendToTeam('team-1', {
+        title: 't',
+        body: 'b',
+      });
+
+      expect(result).toEqual([]);
+      expect(mockPrisma.pushToken.findMany).not.toHaveBeenCalled();
+    });
+
+    it('unions member playerIds and staff userIds, then fans out to sendToUsers', async () => {
+      (mockPrisma.teamMember.findMany as jest.Mock).mockResolvedValue([
+        { playerId: 'player-1' },
+        { playerId: 'player-2' },
+      ]);
+      (mockPrisma.teamStaff.findMany as jest.Mock).mockResolvedValue([
+        { userId: 'coach-1' },
+        // Duplicate with member — Set should dedupe.
+        { userId: 'player-1' },
+      ]);
+      (mockPrisma.pushToken.findMany as jest.Mock).mockResolvedValue([
+        { token: VALID_TOKEN },
+      ]);
+
+      await NotificationService.sendToTeam('team-1', { title: 't', body: 'b' });
+
+      const findManyCall = (mockPrisma.pushToken.findMany as jest.Mock).mock.calls[0][0];
+      const userIds = findManyCall.where.userId.in as string[];
+      expect(userIds).toHaveLength(3);
+      expect(new Set(userIds)).toEqual(new Set(['player-1', 'player-2', 'coach-1']));
+    });
+
+    it('excludes the given userId from the audience', async () => {
+      (mockPrisma.teamMember.findMany as jest.Mock).mockResolvedValue([
+        { playerId: 'player-1' },
+        { playerId: 'player-2' },
+      ]);
+      (mockPrisma.teamStaff.findMany as jest.Mock).mockResolvedValue([
+        { userId: 'coach-1' },
+      ]);
+      (mockPrisma.pushToken.findMany as jest.Mock).mockResolvedValue([
+        { token: VALID_TOKEN },
+      ]);
+
+      await NotificationService.sendToTeam(
+        'team-1',
+        { title: 't', body: 'b' },
+        'player-1'
+      );
+
+      const findManyCall = (mockPrisma.pushToken.findMany as jest.Mock).mock.calls[0][0];
+      const userIds = findManyCall.where.userId.in as string[];
+      expect(userIds).not.toContain('player-1');
+      expect(new Set(userIds)).toEqual(new Set(['player-2', 'coach-1']));
+    });
+
+    it('returns [] when excludeUserId drains the only audience member', async () => {
+      (mockPrisma.teamMember.findMany as jest.Mock).mockResolvedValue([
+        { playerId: 'only-user' },
+      ]);
+      (mockPrisma.teamStaff.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await NotificationService.sendToTeam(
+        'team-1',
+        { title: 't', body: 'b' },
+        'only-user'
+      );
+
+      expect(result).toEqual([]);
+      expect(mockPrisma.pushToken.findMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/tests/services/team-service.test.ts
+++ b/backend/tests/services/team-service.test.ts
@@ -5,6 +5,7 @@
 import { TeamService } from '../../src/services/team-service';
 import { mockPrisma } from '../setup';
 import {
+  createAdmin,
   createCoach,
   createPlayer,
   createTeam,
@@ -616,6 +617,520 @@ describe('TeamService', () => {
       } catch (error) {
         expectNotFoundError(error, 'Player is not on this team');
       }
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Staff management (addStaffMember / removeStaffMember)
+  //
+  // hasTeamPermission fans out: user.findUnique (system admin?) →
+  // team.findUnique (league admin?) → teamStaff.findMany (roles) →
+  // teamMember.findUnique (member-as-player fallback). We set the first check
+  // to ADMIN so the permission short-circuits; that keeps these focused on
+  // the staff-management logic rather than re-testing permissions.
+  // --------------------------------------------------------------------------
+  describe('addStaffMember', () => {
+    it('adds a staff member with the requested role and returns it with user+role included', async () => {
+      const { team } = createFullTeam();
+      const admin = createAdmin();
+      const targetUser = createCoach();
+      const role = createTeamRole({ teamId: team.id, type: 'ASSISTANT_COACH', name: 'Assistant Coach' });
+      const created = createTeamStaff({ teamId: team.id, userId: targetUser.id, roleId: role.id });
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockImplementation(({ where }) => {
+        if (where.id === admin.id) return Promise.resolve(admin);
+        if (where.id === targetUser.id) return Promise.resolve(targetUser);
+        return Promise.resolve(null);
+      });
+      (mockPrisma.teamRole.findUnique as jest.Mock).mockResolvedValue(role);
+      (mockPrisma.teamStaff.findUnique as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.teamStaff.create as jest.Mock).mockResolvedValue({
+        ...created,
+        user: { id: targetUser.id, name: targetUser.name, email: targetUser.email },
+        role,
+      });
+
+      const result = await TeamService.addStaffMember(
+        team.id,
+        targetUser.id,
+        'Assistant Coach',
+        admin.id
+      );
+
+      expect(mockPrisma.teamStaff.create).toHaveBeenCalledWith({
+        data: { teamId: team.id, userId: targetUser.id, roleId: role.id },
+        include: expect.objectContaining({ user: expect.any(Object), role: true }),
+      });
+      expect(result).toMatchObject({
+        teamId: team.id,
+        userId: targetUser.id,
+        roleId: role.id,
+        role: expect.objectContaining({ name: 'Assistant Coach' }),
+      });
+    });
+
+    it('throws NotFoundError when team does not exist', async () => {
+      const admin = createAdmin();
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await TeamService.addStaffMember('missing-team', 'u-1', 'Head Coach', admin.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectNotFoundError(err, 'Team not found');
+      }
+      expect(mockPrisma.teamStaff.create).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenError when requester lacks canManageTeam', async () => {
+      const { team } = createFullTeam();
+      const nonStaff = createPlayer();
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(nonStaff);
+      (mockPrisma.teamStaff.findMany as jest.Mock).mockResolvedValue([]);
+      (mockPrisma.teamMember.findUnique as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await TeamService.addStaffMember(team.id, 'u-1', 'Head Coach', nonStaff.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectForbiddenError(err, 'You do not have permission to manage team staff');
+      }
+    });
+
+    it('throws NotFoundError when target user does not exist', async () => {
+      const { team } = createFullTeam();
+      const admin = createAdmin();
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockImplementation(({ where }) => {
+        if (where.id === admin.id) return Promise.resolve(admin);
+        return Promise.resolve(null);
+      });
+
+      try {
+        await TeamService.addStaffMember(team.id, 'missing-user', 'Head Coach', admin.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectNotFoundError(err, 'User not found');
+      }
+    });
+
+    it('throws NotFoundError when the named role does not exist on this team', async () => {
+      const { team } = createFullTeam();
+      const admin = createAdmin();
+      const targetUser = createCoach();
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockImplementation(({ where }) => {
+        if (where.id === admin.id) return Promise.resolve(admin);
+        if (where.id === targetUser.id) return Promise.resolve(targetUser);
+        return Promise.resolve(null);
+      });
+      (mockPrisma.teamRole.findUnique as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await TeamService.addStaffMember(team.id, targetUser.id, 'Nonexistent', admin.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectNotFoundError(err, 'Role "Nonexistent" not found for this team');
+      }
+    });
+
+    it('throws BadRequestError when the user already holds that role', async () => {
+      const { team } = createFullTeam();
+      const admin = createAdmin();
+      const targetUser = createCoach();
+      const role = createTeamRole({ teamId: team.id, type: 'HEAD_COACH', name: 'Head Coach' });
+      const existing = createTeamStaff({ teamId: team.id, userId: targetUser.id, roleId: role.id });
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockImplementation(({ where }) => {
+        if (where.id === admin.id) return Promise.resolve(admin);
+        if (where.id === targetUser.id) return Promise.resolve(targetUser);
+        return Promise.resolve(null);
+      });
+      (mockPrisma.teamRole.findUnique as jest.Mock).mockResolvedValue(role);
+      (mockPrisma.teamStaff.findUnique as jest.Mock).mockResolvedValue(existing);
+
+      try {
+        await TeamService.addStaffMember(team.id, targetUser.id, 'Head Coach', admin.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectBadRequestError(err, 'User already has this role on the team');
+      }
+      expect(mockPrisma.teamStaff.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeStaffMember', () => {
+    it('removes staff when role is not HEAD_COACH (skips last-head-coach guard)', async () => {
+      const { team } = createFullTeam();
+      const admin = createAdmin();
+      const role = createTeamRole({ teamId: team.id, type: 'ASSISTANT_COACH', name: 'Assistant Coach' });
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(admin);
+      (mockPrisma.teamRole.findUnique as jest.Mock).mockResolvedValue(role);
+      (mockPrisma.teamStaff.delete as jest.Mock).mockResolvedValue({});
+
+      const result = await TeamService.removeStaffMember(team.id, 'u-1', 'Assistant Coach', admin.id);
+
+      expect(mockPrisma.teamStaff.count).not.toHaveBeenCalled();
+      expect(mockPrisma.teamStaff.delete).toHaveBeenCalledWith({
+        where: {
+          teamId_userId_roleId: { teamId: team.id, userId: 'u-1', roleId: role.id },
+        },
+      });
+      expect(result).toEqual({ success: true });
+    });
+
+    it('blocks removing the last HEAD_COACH with a BadRequestError', async () => {
+      const { team } = createFullTeam();
+      const admin = createAdmin();
+      const role = createTeamRole({ teamId: team.id, type: 'HEAD_COACH', name: 'Head Coach' });
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(admin);
+      (mockPrisma.teamRole.findUnique as jest.Mock).mockResolvedValue(role);
+      (mockPrisma.teamStaff.count as jest.Mock).mockResolvedValue(1);
+
+      try {
+        await TeamService.removeStaffMember(team.id, 'u-1', 'Head Coach', admin.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectBadRequestError(
+          err,
+          'Cannot remove the last Head Coach. Assign another Head Coach first.'
+        );
+      }
+      expect(mockPrisma.teamStaff.delete).not.toHaveBeenCalled();
+    });
+
+    it('allows removing a HEAD_COACH when another head coach remains', async () => {
+      const { team } = createFullTeam();
+      const admin = createAdmin();
+      const role = createTeamRole({ teamId: team.id, type: 'HEAD_COACH', name: 'Head Coach' });
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(admin);
+      (mockPrisma.teamRole.findUnique as jest.Mock).mockResolvedValue(role);
+      (mockPrisma.teamStaff.count as jest.Mock).mockResolvedValue(2);
+      (mockPrisma.teamStaff.delete as jest.Mock).mockResolvedValue({});
+
+      const result = await TeamService.removeStaffMember(team.id, 'u-1', 'Head Coach', admin.id);
+
+      expect(result).toEqual({ success: true });
+      expect(mockPrisma.teamStaff.delete).toHaveBeenCalled();
+    });
+
+    it('throws NotFoundError when team does not exist', async () => {
+      const admin = createAdmin();
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await TeamService.removeStaffMember('missing', 'u-1', 'Head Coach', admin.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectNotFoundError(err, 'Team not found');
+      }
+    });
+
+    it('throws ForbiddenError when requester lacks canManageTeam', async () => {
+      const { team } = createFullTeam();
+      const nonStaff = createPlayer();
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(nonStaff);
+      (mockPrisma.teamStaff.findMany as jest.Mock).mockResolvedValue([]);
+      (mockPrisma.teamMember.findUnique as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await TeamService.removeStaffMember(team.id, 'u-1', 'Head Coach', nonStaff.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectForbiddenError(err, 'You do not have permission to manage team staff');
+      }
+    });
+
+    it('throws NotFoundError when the named role does not exist on this team', async () => {
+      const { team } = createFullTeam();
+      const admin = createAdmin();
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(admin);
+      (mockPrisma.teamRole.findUnique as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await TeamService.removeStaffMember(team.id, 'u-1', 'Ghost', admin.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectNotFoundError(err, 'Role "Ghost" not found for this team');
+      }
+    });
+  });
+
+  describe('createCustomRole', () => {
+    it('creates a CUSTOM role with defaults: canViewStats=true, others=false', async () => {
+      const { team } = createFullTeam();
+      const admin = createAdmin();
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(admin);
+      (mockPrisma.teamRole.findUnique as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.teamRole.create as jest.Mock).mockImplementation(({ data }) =>
+        Promise.resolve({ id: 'role-new', ...data })
+      );
+
+      const result = await TeamService.createCustomRole(
+        team.id,
+        { name: 'Scorekeeper' },
+        admin.id
+      );
+
+      expect(mockPrisma.teamRole.create).toHaveBeenCalledWith({
+        data: {
+          teamId: team.id,
+          type: 'CUSTOM',
+          name: 'Scorekeeper',
+          description: undefined,
+          canManageTeam: false,
+          canManageRoster: false,
+          canTrackStats: false,
+          canViewStats: true,
+          canShareStats: false,
+        },
+      });
+      expect(result).toMatchObject({
+        name: 'Scorekeeper',
+        type: 'CUSTOM',
+        canViewStats: true,
+        canManageTeam: false,
+      });
+    });
+
+    it('honors caller-supplied permission flags and description', async () => {
+      const { team } = createFullTeam();
+      const admin = createAdmin();
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(admin);
+      (mockPrisma.teamRole.findUnique as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.teamRole.create as jest.Mock).mockImplementation(({ data }) =>
+        Promise.resolve({ id: 'role-new', ...data })
+      );
+
+      await TeamService.createCustomRole(
+        team.id,
+        {
+          name: 'Stats Lead',
+          description: 'Runs the scorebook',
+          canTrackStats: true,
+          canShareStats: true,
+          canViewStats: false,
+        },
+        admin.id
+      );
+
+      expect(mockPrisma.teamRole.create).toHaveBeenCalledWith({
+        data: {
+          teamId: team.id,
+          type: 'CUSTOM',
+          name: 'Stats Lead',
+          description: 'Runs the scorebook',
+          canManageTeam: false,
+          canManageRoster: false,
+          canTrackStats: true,
+          canViewStats: false,
+          canShareStats: true,
+        },
+      });
+    });
+
+    it('throws NotFoundError when team does not exist', async () => {
+      const admin = createAdmin();
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await TeamService.createCustomRole('missing', { name: 'X' }, admin.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectNotFoundError(err, 'Team not found');
+      }
+    });
+
+    it('throws ForbiddenError when requester lacks canManageTeam', async () => {
+      const { team } = createFullTeam();
+      const nonStaff = createPlayer();
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(nonStaff);
+      (mockPrisma.teamStaff.findMany as jest.Mock).mockResolvedValue([]);
+      (mockPrisma.teamMember.findUnique as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await TeamService.createCustomRole(team.id, { name: 'X' }, nonStaff.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectForbiddenError(err, 'You do not have permission to create team roles');
+      }
+      expect(mockPrisma.teamRole.create).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestError when a role with the given name already exists', async () => {
+      const { team } = createFullTeam();
+      const admin = createAdmin();
+      const existing = createTeamRole({ teamId: team.id, name: 'Scorekeeper' });
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(admin);
+      (mockPrisma.teamRole.findUnique as jest.Mock).mockResolvedValue(existing);
+
+      try {
+        await TeamService.createCustomRole(team.id, { name: 'Scorekeeper' }, admin.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectBadRequestError(err, 'A role with this name already exists');
+      }
+      expect(mockPrisma.teamRole.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getTeamRoles', () => {
+    it('returns all roles for a team (ordered by type, then name) when user has access', async () => {
+      const { team } = createFullTeam();
+      const admin = createAdmin();
+      const roles = [
+        createTeamRole({ teamId: team.id, type: 'HEAD_COACH', name: 'Head Coach' }),
+        createTeamRole({ teamId: team.id, type: 'ASSISTANT_COACH', name: 'Assistant Coach' }),
+      ].map(r => ({ ...r, staff: [] }));
+
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(admin);
+      (mockPrisma.teamRole.findMany as jest.Mock).mockResolvedValue(roles);
+
+      const result = await TeamService.getTeamRoles(team.id, admin.id);
+
+      expect(mockPrisma.teamRole.findMany).toHaveBeenCalledWith({
+        where: { teamId: team.id },
+        include: expect.objectContaining({ staff: expect.any(Object) }),
+        orderBy: [{ type: 'asc' }, { name: 'asc' }],
+      });
+      expect(result).toHaveLength(2);
+    });
+
+    it('throws ForbiddenError when user has no access to the team', async () => {
+      const { team } = createFullTeam();
+      const outsider = createPlayer();
+
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(outsider);
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue({
+        ...team,
+        season: { league: { admins: [] } },
+      });
+      (mockPrisma.teamStaff.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.teamMember.findUnique as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await TeamService.getTeamRoles(team.id, outsider.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectForbiddenError(err, 'You do not have access to this team');
+      }
+      expect(mockPrisma.teamRole.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('addManagedPlayer', () => {
+    it('creates a managed user and links them to the team with jersey + position', async () => {
+      const { team } = createFullTeam();
+      const admin = createAdmin();
+      const managedUser = {
+        id: 'managed-1',
+        name: 'Junior Smith',
+        email: null,
+        isManaged: true,
+        managedById: admin.id,
+      };
+      const teamMember = {
+        id: 'tm-1',
+        teamId: team.id,
+        playerId: managedUser.id,
+        jerseyNumber: 7,
+        position: 'PG',
+        player: {
+          id: managedUser.id,
+          name: managedUser.name,
+          email: null,
+          isManaged: true,
+          managedById: admin.id,
+        },
+        team: { id: team.id, name: team.name },
+      };
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(admin);
+      (mockPrisma.user.create as jest.Mock).mockResolvedValue(managedUser);
+      (mockPrisma.teamMember.create as jest.Mock).mockResolvedValue(teamMember);
+
+      const result = await TeamService.addManagedPlayer(
+        team.id,
+        { name: 'Junior Smith', jerseyNumber: 7, position: 'PG' },
+        admin.id
+      );
+
+      expect(mockPrisma.user.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          name: 'Junior Smith',
+          role: 'PLAYER',
+          isManaged: true,
+          managedById: admin.id,
+          email: null,
+        }),
+      });
+      expect(mockPrisma.teamMember.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            teamId: team.id,
+            playerId: managedUser.id,
+            jerseyNumber: 7,
+            position: 'PG',
+          }),
+        })
+      );
+      expect(result).toMatchObject({ playerId: managedUser.id, jerseyNumber: 7 });
+    });
+
+    it('throws NotFoundError when team does not exist', async () => {
+      const admin = createAdmin();
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await TeamService.addManagedPlayer('missing', { name: 'X' }, admin.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectNotFoundError(err, 'Team not found');
+      }
+      expect(mockPrisma.user.create).not.toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenError when requester lacks canManageRoster', async () => {
+      const { team } = createFullTeam();
+      const nonStaff = createPlayer();
+
+      (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+      (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(nonStaff);
+      (mockPrisma.teamStaff.findMany as jest.Mock).mockResolvedValue([]);
+      (mockPrisma.teamMember.findUnique as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await TeamService.addManagedPlayer(team.id, { name: 'X' }, nonStaff.id);
+        fail('expected to throw');
+      } catch (err) {
+        expectForbiddenError(err, "You do not have permission to manage this team's roster");
+      }
+      expect(mockPrisma.user.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/tests/setup.ts
+++ b/backend/tests/setup.ts
@@ -178,6 +178,17 @@ export const mockPrisma = {
     delete: jest.fn(),
     count: jest.fn(),
   },
+  pushToken: {
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    upsert: jest.fn(),
+    delete: jest.fn(),
+    deleteMany: jest.fn(),
+    count: jest.fn(),
+  },
   $transaction: jest.fn(),
   $disconnect: jest.fn(),
 };


### PR DESCRIPTION
## Summary

Pass 2 of the backend coverage ratchet tracked in #51. Targeted the two highest-gap services from pass 1's report.

- **notification-service**: 15.62% → 100% stmts (new test file — Expo push SDK mocked via moduleNameMapper)
- **team-service**: 68.29% → 97.56% stmts (added staff-management, custom-role, managed-player specs)
- Added pushToken to the shared Prisma mock in tests/setup.ts

## Coverage (before → after)

| Scope     | stmts          | branches       | funcs          | lines          |
| --------- | -------------- | -------------- | -------------- | -------------- |
| global    | 79.70 → 82.82  | 59.49 → 62.20  | 83.09 → 87.41  | 79.99 → 83.05  |
| services  | 75.34 → 81.36  | 61.78 → 67.19  | 78.57 → 88.09  | 75.82 → 81.76  |

Tests: 728 → 761 (+33). All suites green.

## Thresholds (never lowered)

- global: stmts 79→82, branches 56→57, funcs 82→86, lines 79→82
- services: stmts 74→80, branches 60→65, funcs 77→86, lines 74→80

Global branches floor stays calibrated to Jest's threshold-global computation (57.19% on CI), which runs lower than the istanbul summary — the same quirk documented in the prior ratchet commit.

## Quality notes

- Tests assert real behavior: exact create/delete payload shapes, error types + messages, Set-based dedupe, excludeUserId drain, Expo payload shape (including sound: 'default' and data defaulting to {}), and error swallowing in the send loop.
- No production code changes. No eslint-disable. No warnings introduced (lint baseline unchanged at 229).
- Did not touch mobile — separate parallel agent's track.

## Suggested next-pass targets

- stats-service.ts still at 55.85% stmts — lines 899-1202 remain the largest uncovered block.
- game-service.ts at 59.55% stmts — lines 154-255.
- league-service.ts at 64.7% stmts — lines 293-413.

## Test plan

- [x] npm test -- --coverage — 761 passed, thresholds met
- [x] npm run lint — 0 errors, no new warnings
- [x] npx tsc --noEmit — clean

Refs #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)