### PR TITLE
test(mobile): raise coverage from 27% to 49% (#51)

### DIFF
--- a/mobile/__tests__/components/stats/SeasonAverages.test.tsx
+++ b/mobile/__tests__/components/stats/SeasonAverages.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { SeasonAverages } from '../../../components/stats/SeasonAverages';
+import type {
+  AggregatedPlayerStats,
+  TeamSeasonStats,
+} from '../../../types/stats';
+
+const basePlayerStats: AggregatedPlayerStats = {
+  pointsPerGame: 18.5,
+  reboundsPerGame: 7.2,
+  assistsPerGame: 4.1,
+  gamesPlayed: 12,
+} as unknown as AggregatedPlayerStats;
+
+describe('SeasonAverages', () => {
+  it('renders title and the three averages rounded to one decimal', () => {
+    const { getByText } = render(<SeasonAverages stats={basePlayerStats} />);
+    expect(getByText('Season Averages')).toBeTruthy();
+    expect(getByText('PPG')).toBeTruthy();
+    expect(getByText('RPG')).toBeTruthy();
+    expect(getByText('APG')).toBeTruthy();
+    expect(getByText('18.5')).toBeTruthy();
+    expect(getByText('7.2')).toBeTruthy();
+    expect(getByText('4.1')).toBeTruthy();
+  });
+
+  it('renders pluralized games played for N > 1', () => {
+    const { getByText } = render(<SeasonAverages stats={basePlayerStats} />);
+    expect(getByText('12 games played')).toBeTruthy();
+  });
+
+  it('renders singular games played for N === 1', () => {
+    const single = {
+      ...basePlayerStats,
+      gamesPlayed: 1,
+    } as AggregatedPlayerStats;
+    const { getByText } = render(<SeasonAverages stats={single} />);
+    expect(getByText('1 game played')).toBeTruthy();
+  });
+
+  it('omits games played for team stats (no gamesPlayed key)', () => {
+    const teamStats = {
+      pointsPerGame: 80,
+      reboundsPerGame: 40,
+      assistsPerGame: 20,
+    } as unknown as TeamSeasonStats;
+    const { queryByText } = render(<SeasonAverages stats={teamStats} />);
+    expect(queryByText(/games played/)).toBeNull();
+  });
+
+  it('accepts custom maxValues without crashing', () => {
+    const { getByText } = render(
+      <SeasonAverages
+        stats={basePlayerStats}
+        maxValues={{ points: 50, rebounds: 20, assists: 15 }}
+      />
+    );
+    expect(getByText('18.5')).toBeTruthy();
+  });
+});

--- a/mobile/__tests__/components/stats/StatRow.test.tsx
+++ b/mobile/__tests__/components/stats/StatRow.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { StatRow } from '../../../components/stats/StatRow';
+
+describe('StatRow', () => {
+  it('renders label and value', () => {
+    const { getByText } = render(<StatRow label="Points" value={24} />);
+    expect(getByText('Points')).toBeTruthy();
+    expect(getByText('24')).toBeTruthy();
+  });
+
+  it('renders string values', () => {
+    const { getByText } = render(<StatRow label="Record" value="10-2" />);
+    expect(getByText('10-2')).toBeTruthy();
+    expect(getByText('Record')).toBeTruthy();
+  });
+
+  it('renders optional subtitle when provided', () => {
+    const { getByText } = render(
+      <StatRow label="Points" value={24} subtitle="per game" />
+    );
+    expect(getByText('per game')).toBeTruthy();
+  });
+
+  it('omits subtitle element when not provided', () => {
+    const { queryByText } = render(<StatRow label="Points" value={24} />);
+    expect(queryByText('per game')).toBeNull();
+  });
+
+  it('renders with each size variant without crashing', () => {
+    for (const size of ['small', 'medium', 'large'] as const) {
+      const { getByText } = render(
+        <StatRow label="PTS" value={10} size={size} />
+      );
+      expect(getByText('PTS')).toBeTruthy();
+      expect(getByText('10')).toBeTruthy();
+    }
+  });
+});

--- a/mobile/__tests__/hooks/useGameEvents.runtime.test.tsx
+++ b/mobile/__tests__/hooks/useGameEvents.runtime.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Runtime tests for useGameEvents hooks.
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+
+import {
+  useGameEvents,
+  useGameEvent,
+  useCreateGameEvent,
+  useDeleteGameEvent,
+  gameEventKeys,
+} from '../../hooks/useGameEvents';
+import { gameKeys } from '../../hooks/useGames';
+import { apiClient } from '../../services/api-client';
+import type { GameEventFilters } from '../../types/game';
+import { createQueryWrapper } from '../utils/queryWrapper';
+
+const mockedGet = apiClient.get as jest.Mock;
+const mockedPost = apiClient.post as jest.Mock;
+const mockedDelete = apiClient.delete as jest.Mock;
+
+describe('useGameEvents runtime', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('fetches events for a game', async () => {
+    const events = [{ id: 'e1' }];
+    mockedGet.mockResolvedValueOnce({ data: { events } });
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useGameEvents('g1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(events);
+    expect(mockedGet).toHaveBeenCalledWith('/games/g1/events?');
+  });
+
+  it('serializes filters into the query string', async () => {
+    mockedGet.mockResolvedValueOnce({ data: { events: [] } });
+    const { wrapper } = createQueryWrapper();
+    const filters = {
+      eventType: 'SHOT',
+      playerId: 'p1',
+      limit: 5,
+      offset: 10,
+    } as unknown as GameEventFilters;
+    const { result } = renderHook(() => useGameEvents('g1', filters), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const url = mockedGet.mock.calls[0][0] as string;
+    expect(url).toContain('eventType=SHOT');
+    expect(url).toContain('playerId=p1');
+    expect(url).toContain('limit=5');
+    expect(url).toContain('offset=10');
+  });
+
+  it('useGameEvents is disabled without a gameId', () => {
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useGameEvents(''), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fetches a single game event', async () => {
+    const event = { id: 'e1' };
+    mockedGet.mockResolvedValueOnce({ data: { event } });
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useGameEvent('g1', 'e1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(event);
+    expect(mockedGet).toHaveBeenCalledWith('/games/g1/events/e1');
+  });
+
+  it('useGameEvent is disabled when either id is empty', () => {
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useGameEvent('g1', ''), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('creates an event and invalidates list + game detail caches', async () => {
+    const event = { id: 'e1' };
+    mockedPost.mockResolvedValueOnce({ data: { event } });
+
+    const { wrapper, client } = createQueryWrapper();
+    const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useCreateGameEvent(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        gameId: 'g1',
+        data: { eventType: 'SHOT' } as unknown as Parameters<
+          typeof result.current.mutateAsync
+        >[0]['data'],
+      });
+    });
+
+    expect(mockedPost).toHaveBeenCalledWith('/games/g1/events', { eventType: 'SHOT' });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: gameEventKeys.list('g1'),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: gameKeys.detail('g1'),
+    });
+  });
+
+  it('deletes an event and invalidates list + game detail caches', async () => {
+    mockedDelete.mockResolvedValueOnce({ data: {} });
+    const { wrapper, client } = createQueryWrapper();
+    const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useDeleteGameEvent(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ gameId: 'g1', eventId: 'e1' });
+    });
+
+    expect(mockedDelete).toHaveBeenCalledWith('/games/g1/events/e1');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: gameEventKeys.list('g1'),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: gameKeys.detail('g1'),
+    });
+  });
+});

--- a/mobile/__tests__/hooks/useGames.runtime.test.tsx
+++ b/mobile/__tests__/hooks/useGames.runtime.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * Runtime tests for useGames hooks.
+ *
+ * Exercises the actual React Query hook execution, asserting that
+ * query functions call the expected apiClient endpoint, return the
+ * shape the UI consumes, and that mutations invalidate the correct
+ * caches.
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+
+import {
+  useGames,
+  useGame,
+  useCreateGame,
+  useUpdateGame,
+  useDeleteGame,
+  useGameRsvps,
+  useSubmitRsvp,
+  gameKeys,
+  rsvpKeys,
+} from '../../hooks/useGames';
+import { apiClient } from '../../services/api-client';
+import { createQueryWrapper } from '../utils/queryWrapper';
+
+const mockedGet = apiClient.get as jest.Mock;
+const mockedPost = apiClient.post as jest.Mock;
+const mockedPatch = apiClient.patch as jest.Mock;
+const mockedDelete = apiClient.delete as jest.Mock;
+
+describe('useGames runtime', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('useGames query', () => {
+    it('fetches list of games and returns data', async () => {
+      const games = [{ id: 'g1', name: 'Game 1' }];
+      mockedGet.mockResolvedValueOnce({ data: { games } });
+
+      const { wrapper } = createQueryWrapper();
+      const { result } = renderHook(() => useGames(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(games);
+      expect(mockedGet).toHaveBeenCalledWith('/games?');
+    });
+
+    it('serializes filters into the query string', async () => {
+      mockedGet.mockResolvedValueOnce({ data: { games: [] } });
+      const { wrapper } = createQueryWrapper();
+      const { result } = renderHook(
+        () =>
+          useGames({
+            teamId: 't1',
+            status: 'SCHEDULED',
+            startDate: '2026-01-01',
+            endDate: '2026-12-31',
+            limit: 10,
+            offset: 20,
+          }),
+        { wrapper }
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      const url = mockedGet.mock.calls[0][0] as string;
+      expect(url).toContain('teamId=t1');
+      expect(url).toContain('status=SCHEDULED');
+      expect(url).toContain('startDate=2026-01-01');
+      expect(url).toContain('endDate=2026-12-31');
+      expect(url).toContain('limit=10');
+      expect(url).toContain('offset=20');
+    });
+
+    it('surfaces errors when the request fails', async () => {
+      mockedGet.mockRejectedValueOnce(new Error('boom'));
+      const { wrapper } = createQueryWrapper();
+      const { result } = renderHook(() => useGames(), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect((result.current.error as Error).message).toBe('boom');
+    });
+  });
+
+  describe('useGame query', () => {
+    it('fetches a single game by id', async () => {
+      const game = { id: 'g1', name: 'Game 1' };
+      mockedGet.mockResolvedValueOnce({ data: { game } });
+
+      const { wrapper } = createQueryWrapper();
+      const { result } = renderHook(() => useGame('g1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(game);
+      expect(mockedGet).toHaveBeenCalledWith('/games/g1');
+    });
+
+    it('is disabled when gameId is empty', () => {
+      const { wrapper } = createQueryWrapper();
+      const { result } = renderHook(() => useGame(''), { wrapper });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(mockedGet).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useCreateGame mutation', () => {
+    it('posts and invalidates games list on success', async () => {
+      const created = { id: 'g1', name: 'New' };
+      mockedPost.mockResolvedValueOnce({ data: { game: created } });
+
+      const { wrapper, client } = createQueryWrapper();
+      const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+      const { result } = renderHook(() => useCreateGame(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          name: 'New',
+          teamId: 't1',
+          scheduledAt: '2026-05-01T00:00:00Z',
+        } as unknown as Parameters<typeof result.current.mutateAsync>[0]);
+      });
+
+      expect(mockedPost).toHaveBeenCalledWith(
+        '/games',
+        expect.objectContaining({ name: 'New' })
+      );
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: gameKeys.lists() });
+    });
+  });
+
+  describe('useUpdateGame mutation', () => {
+    it('patches and invalidates list + detail caches', async () => {
+      const updated = { id: 'g1', name: 'Updated' };
+      mockedPatch.mockResolvedValueOnce({ data: { game: updated } });
+
+      const { wrapper, client } = createQueryWrapper();
+      const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+      const { result } = renderHook(() => useUpdateGame(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          gameId: 'g1',
+          data: { name: 'Updated' } as unknown as Parameters<
+            typeof result.current.mutateAsync
+          >[0]['data'],
+        });
+      });
+
+      expect(mockedPatch).toHaveBeenCalledWith('/games/g1', { name: 'Updated' });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: gameKeys.lists() });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: gameKeys.detail('g1'),
+      });
+    });
+  });
+
+  describe('useDeleteGame mutation', () => {
+    it('deletes and invalidates games list', async () => {
+      mockedDelete.mockResolvedValueOnce({ data: {} });
+      const { wrapper, client } = createQueryWrapper();
+      const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+      const { result } = renderHook(() => useDeleteGame(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync('g1');
+      });
+
+      expect(mockedDelete).toHaveBeenCalledWith('/games/g1');
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: gameKeys.lists() });
+    });
+  });
+
+  describe('useGameRsvps query', () => {
+    it('fetches rsvps for a game', async () => {
+      const payload = {
+        success: true,
+        rsvps: [{ id: 'r1' }],
+        summary: { going: 1, notGoing: 0, maybe: 0 },
+      };
+      mockedGet.mockResolvedValueOnce({ data: payload });
+
+      const { wrapper } = createQueryWrapper();
+      const { result } = renderHook(() => useGameRsvps('g1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(payload);
+      expect(mockedGet).toHaveBeenCalledWith('/games/g1/rsvps');
+    });
+
+    it('is disabled without a gameId', () => {
+      const { wrapper } = createQueryWrapper();
+      const { result } = renderHook(() => useGameRsvps(''), { wrapper });
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+  });
+
+  describe('useSubmitRsvp mutation', () => {
+    it('submits an rsvp and invalidates that game rsvps cache', async () => {
+      const rsvp = { id: 'r1', status: 'GOING' };
+      mockedPost.mockResolvedValueOnce({ data: { success: true, rsvp } });
+
+      const { wrapper, client } = createQueryWrapper();
+      const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+      const { result } = renderHook(() => useSubmitRsvp(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          gameId: 'g1',
+          status: 'GOING' as unknown as Parameters<
+            typeof result.current.mutateAsync
+          >[0]['status'],
+        });
+      });
+
+      expect(mockedPost).toHaveBeenCalledWith('/games/g1/rsvp', { status: 'GOING' });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: rsvpKeys.game('g1'),
+      });
+    });
+  });
+});

--- a/mobile/__tests__/hooks/useInvitations.runtime.test.tsx
+++ b/mobile/__tests__/hooks/useInvitations.runtime.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * Runtime tests for useInvitations hooks.
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+
+import {
+  useInvitations,
+  useInvitation,
+  useTeamInvitations,
+  usePlayerInvitations,
+  useCreateInvitation,
+  useAcceptInvitation,
+  useRejectInvitation,
+  useCancelInvitation,
+  invitationKeys,
+} from '../../hooks/useInvitations';
+import { apiClient } from '../../services/api-client';
+import { createQueryWrapper } from '../utils/queryWrapper';
+
+const mockedGet = apiClient.get as jest.Mock;
+const mockedPost = apiClient.post as jest.Mock;
+const mockedDelete = apiClient.delete as jest.Mock;
+
+describe('useInvitations runtime', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('fetches invitations with no params', async () => {
+    const payload = {
+      success: true,
+      invitations: [],
+      pagination: { total: 0, limit: 20, offset: 0, hasMore: false },
+    };
+    mockedGet.mockResolvedValueOnce({ data: payload });
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useInvitations(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(payload);
+    expect(mockedGet).toHaveBeenCalledWith('/invitations', { params: undefined });
+  });
+
+  it('passes query params through to apiClient', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        success: true,
+        invitations: [],
+        pagination: { total: 0, limit: 0, offset: 0, hasMore: false },
+      },
+    });
+    const { wrapper } = createQueryWrapper();
+    const params = { status: 'PENDING' as const, teamId: 't1' };
+    const { result } = renderHook(() => useInvitations(params), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockedGet).toHaveBeenCalledWith('/invitations', { params });
+  });
+
+  it('fetches a single invitation by id', async () => {
+    const response = { success: true, invitation: { id: 'inv-1' } };
+    mockedGet.mockResolvedValueOnce({ data: response });
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useInvitation('inv-1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(response);
+    expect(mockedGet).toHaveBeenCalledWith('/invitations/inv-1');
+  });
+
+  it('useInvitation is disabled without an id', () => {
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useInvitation(''), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('useTeamInvitations forwards teamId + status to useInvitations', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        success: true,
+        invitations: [],
+        pagination: { total: 0, limit: 0, offset: 0, hasMore: false },
+      },
+    });
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useTeamInvitations('t1', 'PENDING'), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockedGet).toHaveBeenCalledWith('/invitations', {
+      params: { teamId: 't1', status: 'PENDING' },
+    });
+  });
+
+  it('usePlayerInvitations forwards only status', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        success: true,
+        invitations: [],
+        pagination: { total: 0, limit: 0, offset: 0, hasMore: false },
+      },
+    });
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => usePlayerInvitations('ACCEPTED'), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockedGet).toHaveBeenCalledWith('/invitations', {
+      params: { status: 'ACCEPTED' },
+    });
+  });
+
+  it('useCreateInvitation posts and invalidates list + team caches', async () => {
+    const response = { success: true, invitation: { id: 'inv-1' } };
+    mockedPost.mockResolvedValueOnce({ data: response });
+    const { wrapper, client } = createQueryWrapper();
+    const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useCreateInvitation(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        teamId: 't1',
+        data: { playerId: 'p1' },
+      });
+    });
+
+    expect(mockedPost).toHaveBeenCalledWith('/teams/t1/invitations', {
+      playerId: 'p1',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: invitationKeys.lists(),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: invitationKeys.team('t1'),
+    });
+  });
+
+  it('useAcceptInvitation invalidates all invitations and teams when teamMember present', async () => {
+    const response = {
+      success: true,
+      invitation: { id: 'inv-1' },
+      teamMember: { id: 'tm-1', teamId: 't1', playerId: 'p1' },
+    };
+    mockedPost.mockResolvedValueOnce({ data: response });
+    const { wrapper, client } = createQueryWrapper();
+    const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useAcceptInvitation(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync('inv-1');
+    });
+
+    expect(mockedPost).toHaveBeenCalledWith('/invitations/inv-1/accept');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: invitationKeys.all,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['teams'] });
+  });
+
+  it('useAcceptInvitation does not invalidate teams when teamMember absent', async () => {
+    const response = { success: true, invitation: { id: 'inv-1' } };
+    mockedPost.mockResolvedValueOnce({ data: response });
+    const { wrapper, client } = createQueryWrapper();
+    const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useAcceptInvitation(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync('inv-1');
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: invitationKeys.all,
+    });
+    expect(
+      invalidateSpy.mock.calls.some(
+        (c) => JSON.stringify(c[0]?.queryKey) === JSON.stringify(['teams'])
+      )
+    ).toBe(false);
+  });
+
+  it('useRejectInvitation posts and invalidates all invitations', async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: { success: true, invitation: { id: 'inv-1' } },
+    });
+    const { wrapper, client } = createQueryWrapper();
+    const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useRejectInvitation(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync('inv-1');
+    });
+
+    expect(mockedPost).toHaveBeenCalledWith('/invitations/inv-1/reject');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: invitationKeys.all,
+    });
+  });
+
+  it('useCancelInvitation deletes and invalidates all invitations', async () => {
+    mockedDelete.mockResolvedValueOnce({
+      data: { success: true, invitation: { id: 'inv-1' } },
+    });
+    const { wrapper, client } = createQueryWrapper();
+    const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useCancelInvitation(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync('inv-1');
+    });
+
+    expect(mockedDelete).toHaveBeenCalledWith('/invitations/inv-1');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: invitationKeys.all,
+    });
+  });
+});

--- a/mobile/__tests__/hooks/useSeasons.runtime.test.tsx
+++ b/mobile/__tests__/hooks/useSeasons.runtime.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Runtime tests for useSeasons hooks.
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+
+import {
+  useSeasons,
+  useSeason,
+  useCreateSeason,
+  useUpdateSeason,
+  useDeleteSeason,
+  seasonKeys,
+} from '../../hooks/useSeasons';
+import { apiClient } from '../../services/api-client';
+import { createQueryWrapper } from '../utils/queryWrapper';
+
+const mockedGet = apiClient.get as jest.Mock;
+const mockedPost = apiClient.post as jest.Mock;
+const mockedPatch = apiClient.patch as jest.Mock;
+const mockedDelete = apiClient.delete as jest.Mock;
+
+describe('useSeasons runtime', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('fetches seasons list without filters', async () => {
+    const payload = { success: true, seasons: [], total: 0, limit: 0, offset: 0 };
+    mockedGet.mockResolvedValueOnce({ data: payload });
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSeasons(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(payload);
+    expect(mockedGet).toHaveBeenCalledWith('/seasons?');
+  });
+
+  it('serializes all filter params', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: { success: true, seasons: [], total: 0, limit: 0, offset: 0 },
+    });
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(
+      () =>
+        useSeasons({
+          leagueId: 'l1',
+          isActive: false,
+          search: 'spring',
+          limit: 5,
+          offset: 10,
+        }),
+      { wrapper }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const url = mockedGet.mock.calls[0][0] as string;
+    expect(url).toContain('leagueId=l1');
+    expect(url).toContain('isActive=false');
+    expect(url).toContain('search=spring');
+    expect(url).toContain('limit=5');
+    expect(url).toContain('offset=10');
+  });
+
+  it('fetches a single season by id', async () => {
+    const season = { id: 's1', name: 'Spring' };
+    mockedGet.mockResolvedValueOnce({ data: { success: true, season } });
+
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSeason('s1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(season);
+    expect(mockedGet).toHaveBeenCalledWith('/seasons/s1');
+  });
+
+  it('useSeason is disabled without id', () => {
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSeason(''), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('creates a season and invalidates list + parent league detail', async () => {
+    const season = { id: 's1', leagueId: 'l1' };
+    mockedPost.mockResolvedValueOnce({ data: { success: true, season } });
+
+    const { wrapper, client } = createQueryWrapper();
+    const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useCreateSeason(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ leagueId: 'l1', name: 'Spring' });
+    });
+
+    expect(mockedPost).toHaveBeenCalledWith('/seasons', {
+      leagueId: 'l1',
+      name: 'Spring',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: seasonKeys.lists() });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['leagues', 'detail', 'l1'],
+    });
+  });
+
+  it('updates a season and invalidates list + detail caches', async () => {
+    const season = { id: 's1', leagueId: 'l1' };
+    mockedPatch.mockResolvedValueOnce({ data: { success: true, season } });
+
+    const { wrapper, client } = createQueryWrapper();
+    const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateSeason(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        seasonId: 's1',
+        data: { name: 'Renamed' },
+      });
+    });
+
+    expect(mockedPatch).toHaveBeenCalledWith('/seasons/s1', { name: 'Renamed' });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: seasonKeys.lists() });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: seasonKeys.detail('s1'),
+    });
+  });
+
+  it('deletes a season and invalidates lists', async () => {
+    mockedDelete.mockResolvedValueOnce({ data: {} });
+    const { wrapper, client } = createQueryWrapper();
+    const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useDeleteSeason(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync('s1');
+    });
+
+    expect(mockedDelete).toHaveBeenCalledWith('/seasons/s1');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: seasonKeys.lists() });
+  });
+});

--- a/mobile/__tests__/hooks/useStats.runtime.test.tsx
+++ b/mobile/__tests__/hooks/useStats.runtime.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Runtime tests for useStats hooks.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useBoxScore,
+  usePlayerGameStats,
+  usePlayerOverallStats,
+  usePlayerSeasonStats,
+  useTeamSeasonStats,
+  useTeamRosterStats,
+} from '../../hooks/useStats';
+import { apiClient } from '../../services/api-client';
+import { createQueryWrapper } from '../utils/queryWrapper';
+
+const mockedGet = apiClient.get as jest.Mock;
+
+describe('useStats runtime', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('useBoxScore fetches box score for a game', async () => {
+    const boxScore = { gameId: 'g1', home: {}, away: {} };
+    mockedGet.mockResolvedValueOnce({ data: { boxScore } });
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useBoxScore('g1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(boxScore);
+    expect(mockedGet).toHaveBeenCalledWith('/stats/games/g1');
+  });
+
+  it('useBoxScore is disabled without gameId', () => {
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useBoxScore(''), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('usePlayerGameStats fetches player stats for a game', async () => {
+    const stats = { points: 10 };
+    mockedGet.mockResolvedValueOnce({ data: { stats } });
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => usePlayerGameStats('g1', 'p1'), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(stats);
+    expect(mockedGet).toHaveBeenCalledWith('/stats/games/g1/players/p1');
+  });
+
+  it('usePlayerGameStats is disabled when either id missing', () => {
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => usePlayerGameStats('', 'p1'), {
+      wrapper,
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('usePlayerOverallStats returns combined shape', async () => {
+    const response = {
+      player: { id: 'p1' },
+      teams: [{ id: 't1' }],
+      careerTotals: { points: 100 },
+    };
+    mockedGet.mockResolvedValueOnce({ data: response });
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => usePlayerOverallStats('p1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(response);
+    expect(mockedGet).toHaveBeenCalledWith('/stats/players/p1');
+  });
+
+  it('usePlayerSeasonStats fetches season aggregate', async () => {
+    const stats = { gamesPlayed: 3 };
+    mockedGet.mockResolvedValueOnce({ data: { stats } });
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => usePlayerSeasonStats('p1', 't1'), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(stats);
+    expect(mockedGet).toHaveBeenCalledWith('/stats/players/p1/teams/t1');
+  });
+
+  it('useTeamSeasonStats fetches team season stats', async () => {
+    const stats = { wins: 5 };
+    mockedGet.mockResolvedValueOnce({ data: { stats } });
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useTeamSeasonStats('t1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(stats);
+    expect(mockedGet).toHaveBeenCalledWith('/stats/teams/t1');
+  });
+
+  it('useTeamSeasonStats is disabled without teamId', () => {
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useTeamSeasonStats(''), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('useTeamRosterStats returns the players array', async () => {
+    const players = [{ playerId: 'p1' }, { playerId: 'p2' }];
+    mockedGet.mockResolvedValueOnce({ data: { players } });
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useTeamRosterStats('t1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(players);
+    expect(mockedGet).toHaveBeenCalledWith('/stats/teams/t1/players');
+  });
+});

--- a/mobile/__tests__/services/sentry.test.ts
+++ b/mobile/__tests__/services/sentry.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for services/sentry.ts
+ *
+ * Verifies:
+ *   - init is gated on a DSN being present
+ *   - init is idempotent
+ *   - beforeSend scrubs sensitive fields across request/extra/contexts/breadcrumbs
+ *   - setSentryUser no-ops until init has run
+ */
+
+jest.mock('@sentry/react-native', () => ({
+  init: jest.fn(),
+  setUser: jest.fn(),
+}));
+
+jest.mock('expo-constants', () => ({
+  __esModule: true,
+  default: {
+    expoConfig: {
+      extra: {},
+      version: '1.2.3',
+    },
+  },
+}));
+
+import * as Sentry from '@sentry/react-native';
+import Constants from 'expo-constants';
+
+const sentryInit = Sentry.init as jest.Mock;
+const sentrySetUser = Sentry.setUser as jest.Mock;
+
+// Each test re-imports the module so the `initialized` module-level flag
+// starts fresh.
+function loadSentryModule() {
+  let mod!: typeof import('../../services/sentry');
+  jest.isolateModules(() => {
+    mod = require('../../services/sentry');
+  });
+  return mod;
+}
+
+function setExtra(extra: Record<string, unknown> | undefined): void {
+  (Constants as unknown as { expoConfig: { extra: unknown } }).expoConfig.extra =
+    extra;
+}
+
+describe('services/sentry', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setExtra({});
+    delete process.env.SENTRY_DSN;
+    delete process.env.SENTRY_ENVIRONMENT;
+    delete process.env.SENTRY_RELEASE;
+  });
+
+  describe('initSentry', () => {
+    it('no-ops when no DSN is configured', () => {
+      const { initSentry, isSentryEnabled } = loadSentryModule();
+      initSentry();
+      expect(sentryInit).not.toHaveBeenCalled();
+      expect(isSentryEnabled()).toBe(false);
+    });
+
+    it('initializes Sentry when DSN is in expoConfig extras', () => {
+      setExtra({
+        sentryDsn: 'https://test@sentry.io/1',
+        sentryEnvironment: 'staging',
+      });
+      const { initSentry, isSentryEnabled } = loadSentryModule();
+      initSentry();
+      expect(sentryInit).toHaveBeenCalledTimes(1);
+      const cfg = sentryInit.mock.calls[0][0];
+      expect(cfg.dsn).toBe('https://test@sentry.io/1');
+      expect(cfg.environment).toBe('staging');
+      expect(cfg.sendDefaultPii).toBe(false);
+      expect(typeof cfg.beforeSend).toBe('function');
+      expect(isSentryEnabled()).toBe(true);
+    });
+
+    it('falls back to SENTRY_DSN env var', () => {
+      process.env.SENTRY_DSN = 'https://env@sentry.io/2';
+      const { initSentry } = loadSentryModule();
+      initSentry();
+      expect(sentryInit).toHaveBeenCalledTimes(1);
+      expect(sentryInit.mock.calls[0][0].dsn).toBe('https://env@sentry.io/2');
+    });
+
+    it('is idempotent across multiple calls', () => {
+      setExtra({ sentryDsn: 'https://test@sentry.io/1' });
+      const { initSentry } = loadSentryModule();
+      initSentry();
+      initSentry();
+      initSentry();
+      expect(sentryInit).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses sentryRelease from extras when provided', () => {
+      setExtra({
+        sentryDsn: 'https://test@sentry.io/1',
+        sentryRelease: 'my-release-1',
+      });
+      const { initSentry } = loadSentryModule();
+      initSentry();
+      expect(sentryInit.mock.calls[0][0].release).toBe('my-release-1');
+    });
+
+    it('falls back to version from expoConfig when no release set', () => {
+      setExtra({ sentryDsn: 'https://test@sentry.io/1' });
+      const { initSentry } = loadSentryModule();
+      initSentry();
+      expect(sentryInit.mock.calls[0][0].release).toBe('1.2.3');
+    });
+
+    it('stays disabled when Sentry.init throws', () => {
+      setExtra({ sentryDsn: 'https://test@sentry.io/1' });
+      sentryInit.mockImplementationOnce(() => {
+        throw new Error('boom');
+      });
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const { initSentry, isSentryEnabled } = loadSentryModule();
+        initSentry();
+        expect(isSentryEnabled()).toBe(false);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('beforeSend', () => {
+    it('scrubs sensitive headers, cookies, and request body', () => {
+      const { beforeSend } = loadSentryModule();
+      const out = beforeSend({
+        request: {
+          headers: { Authorization: 'Bearer abc', 'X-Safe': 'ok' },
+          cookies: { session: 'secret', other: 'fine' },
+          data: { password: 'hunter2' },
+        },
+      } as unknown as Parameters<typeof beforeSend>[0]);
+
+      expect(out.request?.headers).toEqual({
+        Authorization: '[scrubbed]',
+        'X-Safe': 'ok',
+      });
+      expect(out.request?.cookies).toEqual({
+        session: '[scrubbed]',
+        other: 'fine',
+      });
+      expect(out.request?.data).toBe('[scrubbed]');
+    });
+
+    it('scrubs extra and contexts fields recursively', () => {
+      const { beforeSend } = loadSentryModule();
+      const out = beforeSend({
+        extra: {
+          email: 'user@example.com',
+          nested: { token: 'xyz', keep: 1 },
+        },
+        contexts: {
+          user_ctx: { jwt: 'abc', id: 'u1' },
+        },
+      } as unknown as Parameters<typeof beforeSend>[0]);
+
+      expect((out.extra as Record<string, unknown>).email).toBe('[scrubbed]');
+      expect(
+        (
+          (out.extra as Record<string, unknown>).nested as Record<string, unknown>
+        ).token
+      ).toBe('[scrubbed]');
+      expect(
+        ((out.extra as Record<string, unknown>).nested as Record<string, unknown>)
+          .keep
+      ).toBe(1);
+      expect(
+        (
+          (out.contexts as Record<string, unknown>).user_ctx as Record<
+            string,
+            unknown
+          >
+        ).jwt
+      ).toBe('[scrubbed]');
+    });
+
+    it('scrubs breadcrumb data', () => {
+      const { beforeSend } = loadSentryModule();
+      const out = beforeSend({
+        breadcrumbs: [
+          { message: 'login', data: { password: 'p' } },
+          { message: 'visit', data: { url: '/home' } },
+          { message: 'no-data' },
+        ],
+      } as unknown as Parameters<typeof beforeSend>[0]);
+
+      expect(out.breadcrumbs?.[0].data?.password).toBe('[scrubbed]');
+      expect(out.breadcrumbs?.[1].data?.url).toBe('/home');
+      expect(out.breadcrumbs?.[2].data).toBeUndefined();
+    });
+
+    it('returns the event untouched when no sensitive fields present', () => {
+      const { beforeSend } = loadSentryModule();
+      const event = { message: 'hi', tags: { env: 'test' } };
+      const out = beforeSend(event as unknown as Parameters<typeof beforeSend>[0]);
+      expect(out).toEqual(event);
+    });
+
+    it('handles arrays within scrubbed objects', () => {
+      const { beforeSend } = loadSentryModule();
+      const out = beforeSend({
+        extra: {
+          items: [{ token: 't1' }, { safe: 'ok' }],
+        },
+      } as unknown as Parameters<typeof beforeSend>[0]);
+      const items = (out.extra as { items: Array<Record<string, unknown>> })
+        .items;
+      expect(items[0].token).toBe('[scrubbed]');
+      expect(items[1].safe).toBe('ok');
+    });
+  });
+
+  describe('setSentryUser', () => {
+    it('no-ops when Sentry is not initialized', () => {
+      const { setSentryUser } = loadSentryModule();
+      setSentryUser('u1');
+      expect(sentrySetUser).not.toHaveBeenCalled();
+    });
+
+    it('sets user after init', () => {
+      setExtra({ sentryDsn: 'https://test@sentry.io/1' });
+      const { initSentry, setSentryUser } = loadSentryModule();
+      initSentry();
+      setSentryUser('u1');
+      expect(sentrySetUser).toHaveBeenCalledWith({ id: 'u1' });
+    });
+
+    it('clears user when passed null', () => {
+      setExtra({ sentryDsn: 'https://test@sentry.io/1' });
+      const { initSentry, setSentryUser } = loadSentryModule();
+      initSentry();
+      setSentryUser(null);
+      expect(sentrySetUser).toHaveBeenCalledWith(null);
+    });
+
+    it('swallows errors from Sentry.setUser', () => {
+      setExtra({ sentryDsn: 'https://test@sentry.io/1' });
+      sentrySetUser.mockImplementationOnce(() => {
+        throw new Error('nope');
+      });
+      const { initSentry, setSentryUser } = loadSentryModule();
+      initSentry();
+      expect(() => setSentryUser('u1')).not.toThrow();
+    });
+  });
+});

--- a/mobile/__tests__/utils/queryWrapper.tsx
+++ b/mobile/__tests__/utils/queryWrapper.tsx
@@ -1,0 +1,38 @@
+/**
+ * Test utilities for React Query-backed hooks.
+ *
+ * Provides a fresh `QueryClient` per test with retries disabled so
+ * `useQuery` / `useMutation` hooks resolve/reject deterministically
+ * in a single tick.
+ */
+
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: Infinity,
+        staleTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
+
+export interface QueryWrapper {
+  wrapper: React.FC<{ children: React.ReactNode }>;
+  client: QueryClient;
+}
+
+export function createQueryWrapper(): QueryWrapper {
+  const client = createTestQueryClient();
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { wrapper, client };
+}

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -19,16 +19,19 @@ module.exports = {
   ],
   // Coverage thresholds — floors, not aspirations. CI enforces via
   // `npm test -- --coverage`. Target before GA is 70/60/70/70 per #51.
-  // Current mobile coverage as of 2026-04-12 (after store + services +
-  // useTeams helper tests): stmts 27.36 / branches 34.48 / funcs 21.21 /
-  // lines 27.83. Thresholds set ~1pt below actuals to tolerate trivial
-  // churn. These must only ratchet upward — see issue #51.
+  // Pass 2 (2026-04-12): added React-Query runtime tests for useGames,
+  // useGameEvents, useSeasons, useStats, useInvitations via a new
+  // QueryClient test wrapper; covered services/sentry.ts; added StatRow
+  // + SeasonAverages component tests. Observed: stmts 48.94 /
+  // branches 49.24 / funcs 47.56 / lines 48.81. Thresholds set ~1pt below
+  // actuals to tolerate trivial churn. These must only ratchet upward —
+  // see issue #51.
   coverageThreshold: {
     global: {
-      branches: 33,
-      functions: 20,
-      lines: 26,
-      statements: 26,
+      branches: 48,
+      functions: 46,
+      lines: 47,
+      statements: 47,
     },
   },
   moduleNameMapper: {

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -3,6 +3,18 @@
  * Sets up mocks for native modules and common dependencies
  */
 
+// Polyfill TextEncoder/TextDecoder for jsdom. Expo's winter runtime lazily
+// loads whatwg-url on first `URLSearchParams`/`URL` access, which requires
+// these globals. Without them, hooks that touch URLSearchParams (useGames,
+// useGameEvents, useSeasons, etc.) throw ReferenceError inside the query fn.
+import { TextEncoder, TextDecoder } from 'util';
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+}
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder;
+}
+
 import '@testing-library/react-native';
 
 // Mock AsyncStorage


### PR DESCRIPTION
## Summary
Pass 2 of the mobile coverage ratchet (#51). Big ROI win by adding runtime tests for React-Query-backed hooks through a new `QueryClient` test wrapper, plus full coverage of `services/sentry.ts` and the two simplest stats display components.

- **New test wrapper** (`__tests__/utils/queryWrapper.tsx`): fresh `QueryClient` per test with `retry: false`, used by every new hook suite.
- **Hook runtime tests** (new `*.runtime.test.tsx` alongside the existing key/type tests): `useGames`, `useGameEvents`, `useSeasons`, `useStats`, `useInvitations`. Each suite exercises the happy path (query key → apiClient call → returned data shape), the `enabled: !!id` guard, and mutation cache invalidations (both `.lists()` and `.detail()` / related cross-domain keys).
- **`services/sentry.ts` tests**: DSN gating (extras, env var, neither), idempotent init, release fallbacks (`sentryRelease` → `expoConfig.version`), error safety in `Sentry.init`, recursive scrubbing across `request.headers/cookies/data`, `extra`, `contexts`, and `breadcrumbs[].data`, and `setSentryUser` behavior before/after init.
- **Stats components**: `StatRow` (label/value/subtitle/size variants) and `SeasonAverages` (title, values, singular/plural games played, team-vs-player branch).
- **`jest.setup.js`**: added `TextEncoder` / `TextDecoder` polyfill. Without it, Expo's winter URL runtime crashes inside query functions that touch `URLSearchParams` (e.g. `useGames`, `useGameEvents`, `useSeasons`).

## Coverage delta

| Metric     | Before | After  | Threshold |
|------------|--------|--------|-----------|
| Statements | 27.36  | 48.94  | 47        |
| Branches   | 34.48  | 49.24  | 48        |
| Functions  | 21.21  | 47.56  | 46        |
| Lines      | 27.83  | 48.81  | 47        |

All hook files now at 100% (`useGames`, `useGameEvents`, `useSeasons`, `useStats`, `useInvitations`). `services/sentry.ts` at 95 stmts / 81 branches.

Refs #51.

## Test plan
- [x] `npm test` green (28 suites, 311 tests)
- [x] `npm test -- --coverage` passes thresholds
- [x] `npm run type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)