### PR TITLE
chore(deps): patch 8 open Dependabot alerts via overrides

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2132,9 +2132,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"

--- a/backend/package.json
+++ b/backend/package.json
@@ -53,7 +53,8 @@
     "seed": "tsx prisma/seed.ts"
   },
   "overrides": {
-    "minimatch": "^3.1.3"
+    "minimatch": "^3.1.3",
+    "@hono/node-server": "^1.19.13"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1965,15 +1965,6 @@
       "integrity": "sha512-9ezxaHjxqTkTOLg62SGg7YhFaE+fxa/jlrWP0nwf7eGFHlGOiTAaRR2KUfiN3K05e+EMbEhgcH/c7bgaXeGyJw==",
       "license": "MIT"
     },
-    "node_modules/@expo/cli/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@expo/cli/node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2412,16 +2403,6 @@
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/@expo/config-plugins/node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@expo/config-plugins/node_modules/balanced-match": {
@@ -3221,15 +3202,6 @@
         }
       }
     },
-    "node_modules/@expo/local-build-cache-provider/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@expo/local-build-cache-provider/node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3504,15 +3476,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@expo/metro-config/node_modules/balanced-match": {
@@ -7067,11 +7030,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
-      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
-      "deprecated": "this version has critical issues, please update to the latest version",
-      "dev": true,
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -9686,15 +9647,6 @@
         }
       }
     },
-    "node_modules/expo-constants/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/expo-constants/node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -10040,15 +9992,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo-manifests/node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/expo-manifests/node_modules/balanced-match": {
@@ -10534,15 +10477,6 @@
       "integrity": "sha512-9ezxaHjxqTkTOLg62SGg7YhFaE+fxa/jlrWP0nwf7eGFHlGOiTAaRR2KUfiN3K05e+EMbEhgcH/c7bgaXeGyJw==",
       "license": "MIT"
     },
-    "node_modules/expo-splash-screen/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/expo-splash-screen/node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -10735,15 +10669,6 @@
         "xmlbuilder": "^15.1.1"
       }
     },
-    "node_modules/expo-updates/node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/expo-updates/node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -10907,15 +10832,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/expo/node_modules/ansi-styles": {
@@ -11271,9 +11187,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -12852,16 +12768,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jest-expo/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/jest-expo/node_modules/balanced-match": {
@@ -15188,9 +15094,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -15671,15 +15577,6 @@
       },
       "engines": {
         "node": ">=10.4.0"
-      }
-    },
-    "node_modules/plist/node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/plist/node_modules/xmlbuilder": {
@@ -17701,10 +17598,9 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -81,8 +81,10 @@
     "expo-modules-core": "~55.0.22",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "diff": "8.0.3",
-    "node-forge": "1.3.3",
-    "tar": "7.5.7"
+    "node-forge": "^1.4.0",
+    "tar": "^7.5.8",
+    "@xmldom/xmldom": "^0.8.12",
+    "follow-redirects": "^1.16.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
Closes all 8 open Dependabot alerts (6 high, 2 moderate) by bumping/adding \`overrides\` entries. No production source code changed — security-only dependency shimming.

## Alerts addressed

### Mobile (7)
| Package | Action | CVE / GHSA | Severity |
| --- | --- | --- | --- |
| node-forge | override 1.3.3 → ^1.4.0 | CVE-2026-33891 (modInverse DoS) | high |
| node-forge | ↳ | CVE-2026-33894 (RSA-PKCS forgery) | high |
| node-forge | ↳ | CVE-2026-33895 (Ed25519 forgery) | high |
| node-forge | ↳ | CVE-2026-33896 (cert chain bypass) | high |
| tar | override 7.5.7 → ^7.5.8 | CVE-2026-26960 (hardlink escape) | high |
| @xmldom/xmldom | new override ^0.8.12 | CVE-2026-34601 (CDATA injection) | high |
| follow-redirects | new override ^1.16.0 | GHSA-r4q5-vmmm-2653 (auth header leak) | moderate |

### Backend (1)
| Package | Action | CVE | Severity |
| --- | --- | --- | --- |
| @hono/node-server | new override ^1.19.13 | CVE-2026-39406 (serveStatic bypass) | moderate |

## Notes on approach
- **@xmldom/xmldom**: the 0.7.13 transitive path via older \`@expo/plist@0.2.x\` had no 0.7-line patch available. Forcing it to 0.8.12+ is the only path to a patched version; 0.8 is API-compatible for the attribute/CDATA surface @expo/plist uses.
- **follow-redirects**: axios 1.15.x bundles 1.15.11; adding an override upgrades the transitive without changing our axios constraint.
- **@hono/node-server**: only reaches us via \`prisma → @prisma/dev\` dev tooling; still alert-worthy so we close it anyway.
- Remaining \`npm audit\` findings (eas-cli transitives: @tootallnate/once, ajv) are not surfaced as Dependabot alerts — left alone.

## Test plan
- [x] \`npm ls\` confirms all overrides took effect (node-forge 1.4.0, tar 7.5.13, xmldom 0.8.13, follow-redirects 1.16.0, @hono/node-server 1.19.14)
- [x] Backend: type-check clean, 790/790 tests pass
- [x] Mobile: type-check clean, 311/311 tests pass, \`expo export --platform ios\` succeeds
- [ ] CI green
- [ ] Dependabot alerts auto-close on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)