### PR TITLE
test(mobile): coverage pass 3 — useAnnouncements, useNotifications, game components (#51)

### DIFF
--- a/mobile/__tests__/components/game/OpponentScoreButtons.test.tsx
+++ b/mobile/__tests__/components/game/OpponentScoreButtons.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Tests for OpponentScoreButtons.
+ *
+ * Verifies the four buttons (-1, +1, +2, +3) call the correct prop with
+ * the right argument, that disabling blocks all presses, and that the
+ * label is rendered.
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+import { OpponentScoreButtons } from '../../../components/game/OpponentScoreButtons';
+
+// useTheme — minimal palette covering the keys this component reads.
+jest.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      backgroundSecondary: '#EEE',
+      border: '#DDD',
+      warning: '#F90',
+    },
+    colorScheme: 'light',
+  }),
+}));
+
+describe('OpponentScoreButtons', () => {
+  it('renders the section label and all four buttons', () => {
+    const { getByText } = render(
+      <OpponentScoreButtons onAddPoints={jest.fn()} onSubtractPoint={jest.fn()} />
+    );
+    expect(getByText('Opponent Score')).toBeTruthy();
+    expect(getByText('-1')).toBeTruthy();
+    expect(getByText('+1')).toBeTruthy();
+    expect(getByText('+2')).toBeTruthy();
+    expect(getByText('+3')).toBeTruthy();
+  });
+
+  it('calls onSubtractPoint exactly once when -1 is pressed', () => {
+    const onSubtractPoint = jest.fn();
+    const onAddPoints = jest.fn();
+    const { getByText } = render(
+      <OpponentScoreButtons
+        onAddPoints={onAddPoints}
+        onSubtractPoint={onSubtractPoint}
+      />
+    );
+
+    fireEvent.press(getByText('-1'));
+
+    expect(onSubtractPoint).toHaveBeenCalledTimes(1);
+    expect(onAddPoints).not.toHaveBeenCalled();
+  });
+
+  it('calls onAddPoints with 1 when +1 is pressed', () => {
+    const onAddPoints = jest.fn();
+    const { getByText } = render(
+      <OpponentScoreButtons
+        onAddPoints={onAddPoints}
+        onSubtractPoint={jest.fn()}
+      />
+    );
+
+    fireEvent.press(getByText('+1'));
+
+    expect(onAddPoints).toHaveBeenCalledTimes(1);
+    expect(onAddPoints).toHaveBeenCalledWith(1);
+  });
+
+  it('calls onAddPoints with 2 when +2 is pressed', () => {
+    const onAddPoints = jest.fn();
+    const { getByText } = render(
+      <OpponentScoreButtons
+        onAddPoints={onAddPoints}
+        onSubtractPoint={jest.fn()}
+      />
+    );
+
+    fireEvent.press(getByText('+2'));
+    expect(onAddPoints).toHaveBeenCalledWith(2);
+  });
+
+  it('calls onAddPoints with 3 when +3 is pressed', () => {
+    const onAddPoints = jest.fn();
+    const { getByText } = render(
+      <OpponentScoreButtons
+        onAddPoints={onAddPoints}
+        onSubtractPoint={jest.fn()}
+      />
+    );
+
+    fireEvent.press(getByText('+3'));
+    expect(onAddPoints).toHaveBeenCalledWith(3);
+  });
+
+  it('does not invoke handlers when disabled', () => {
+    const onAddPoints = jest.fn();
+    const onSubtractPoint = jest.fn();
+    const { getByText } = render(
+      <OpponentScoreButtons
+        onAddPoints={onAddPoints}
+        onSubtractPoint={onSubtractPoint}
+        disabled
+      />
+    );
+
+    fireEvent.press(getByText('-1'));
+    fireEvent.press(getByText('+1'));
+    fireEvent.press(getByText('+2'));
+    fireEvent.press(getByText('+3'));
+
+    expect(onAddPoints).not.toHaveBeenCalled();
+    expect(onSubtractPoint).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/__tests__/components/game/PlayerRoster.test.tsx
+++ b/mobile/__tests__/components/game/PlayerRoster.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Tests for PlayerRoster.
+ *
+ * Covers:
+ *   - empty state when no players
+ *   - "Select Player" header + chip rendering when populated
+ *   - jersey-number label takes precedence over initials
+ *   - initials fallback (uppercase, first two of words) when no jersey
+ *   - hot indicator (flame icon) appears only when streak >= 3
+ *   - press dispatches onSelectPlayer with (playerId, playerName)
+ *   - selected state surfaces via accessibilityState
+ *   - selection-only takes the player by playerId, not by member.id
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+import { PlayerRoster } from '../../../components/game/PlayerRoster';
+
+jest.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      backgroundSecondary: '#EEE',
+      border: '#DDD',
+      primary: '#06F',
+      text: '#111',
+      textTertiary: '#999',
+    },
+    colorScheme: 'light',
+  }),
+}));
+
+const player = (overrides: {
+  id?: string;
+  playerId?: string;
+  jerseyNumber?: number;
+  name: string;
+}) => ({
+  id: overrides.id ?? `m-${overrides.playerId ?? overrides.name}`,
+  playerId: overrides.playerId ?? overrides.name,
+  jerseyNumber: overrides.jerseyNumber,
+  player: { id: overrides.playerId ?? overrides.name, name: overrides.name },
+});
+
+describe('PlayerRoster', () => {
+  it('shows the empty state when there are no players', () => {
+    const { getByText, queryByText } = render(
+      <PlayerRoster
+        players={[]}
+        selectedPlayerId={null}
+        onSelectPlayer={jest.fn()}
+      />
+    );
+    expect(getByText('No players on roster')).toBeTruthy();
+    expect(queryByText('Select Player')).toBeNull();
+  });
+
+  it('renders the "Select Player" header and a chip per player when populated', () => {
+    const { getByText } = render(
+      <PlayerRoster
+        players={[
+          player({ playerId: 'p1', name: 'Alice Adams', jerseyNumber: 7 }),
+          player({ playerId: 'p2', name: 'Bob Brown', jerseyNumber: 23 }),
+        ]}
+        selectedPlayerId={null}
+        onSelectPlayer={jest.fn()}
+      />
+    );
+    expect(getByText('Select Player')).toBeTruthy();
+    // First-name labels.
+    expect(getByText('Alice')).toBeTruthy();
+    expect(getByText('Bob')).toBeTruthy();
+  });
+
+  it('shows jersey numbers prefixed with #, not initials, when present', () => {
+    const { getByText, queryByText } = render(
+      <PlayerRoster
+        players={[player({ playerId: 'p1', name: 'Alice Adams', jerseyNumber: 7 })]}
+        selectedPlayerId={null}
+        onSelectPlayer={jest.fn()}
+      />
+    );
+    expect(getByText('#7')).toBeTruthy();
+    expect(queryByText('AA')).toBeNull();
+  });
+
+  it('falls back to initials (first two, uppercased) when no jersey number', () => {
+    const { getByText } = render(
+      <PlayerRoster
+        players={[player({ playerId: 'p1', name: 'alice adams' })]}
+        selectedPlayerId={null}
+        onSelectPlayer={jest.fn()}
+      />
+    );
+    expect(getByText('AA')).toBeTruthy();
+  });
+
+  it('exposes accessibility label including jersey number when present', () => {
+    const { getByLabelText } = render(
+      <PlayerRoster
+        players={[player({ playerId: 'p1', name: 'Alice Adams', jerseyNumber: 7 })]}
+        selectedPlayerId={null}
+        onSelectPlayer={jest.fn()}
+      />
+    );
+    expect(getByLabelText('Alice Adams, number 7')).toBeTruthy();
+  });
+
+  it('omits jersey portion of accessibility label when no jersey number', () => {
+    const { getByLabelText } = render(
+      <PlayerRoster
+        players={[player({ playerId: 'p1', name: 'Alice Adams' })]}
+        selectedPlayerId={null}
+        onSelectPlayer={jest.fn()}
+      />
+    );
+    expect(getByLabelText('Alice Adams')).toBeTruthy();
+  });
+
+  it('dispatches onSelectPlayer with (playerId, name) when chip is pressed', () => {
+    const onSelectPlayer = jest.fn();
+    const { getByLabelText } = render(
+      <PlayerRoster
+        players={[player({ playerId: 'p1', name: 'Alice Adams', jerseyNumber: 7 })]}
+        selectedPlayerId={null}
+        onSelectPlayer={onSelectPlayer}
+      />
+    );
+    fireEvent.press(getByLabelText('Alice Adams, number 7'));
+    expect(onSelectPlayer).toHaveBeenCalledTimes(1);
+    expect(onSelectPlayer).toHaveBeenCalledWith('p1', 'Alice Adams');
+  });
+
+  it('marks the selected chip via accessibilityState', () => {
+    const { getByLabelText } = render(
+      <PlayerRoster
+        players={[
+          player({ playerId: 'p1', name: 'Alice Adams', jerseyNumber: 7 }),
+          player({ playerId: 'p2', name: 'Bob Brown', jerseyNumber: 23 }),
+        ]}
+        selectedPlayerId="p2"
+        onSelectPlayer={jest.fn()}
+      />
+    );
+    expect(
+      getByLabelText('Alice Adams, number 7').props.accessibilityState
+    ).toEqual(expect.objectContaining({ selected: false }));
+    expect(
+      getByLabelText('Bob Brown, number 23').props.accessibilityState
+    ).toEqual(expect.objectContaining({ selected: true }));
+  });
+
+  it('marks a player "hot" only when their streak is >= 3', () => {
+    const { UNSAFE_getAllByType } = render(
+      <PlayerRoster
+        players={[
+          player({ playerId: 'cold', name: 'Cold Player' }),
+          player({ playerId: 'hot', name: 'Hot Player' }),
+        ]}
+        selectedPlayerId={null}
+        onSelectPlayer={jest.fn()}
+        hotPlayers={{ cold: 2, hot: 3 }}
+      />
+    );
+    // The mocked Ionicons component renders the icon name as text — easy to
+    // count flames across the grid.
+    const flames = UNSAFE_getAllByType('Text' as unknown as React.ComponentType).filter(
+      (node) => node.props.name === 'flame'
+    );
+    expect(flames).toHaveLength(1);
+  });
+});

--- a/mobile/__tests__/components/game/ScoreDisplay.test.tsx
+++ b/mobile/__tests__/components/game/ScoreDisplay.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for ScoreDisplay.
+ *
+ * Covers:
+ *   - team names + numeric scores render
+ *   - LIVE badge is shown
+ *   - back button is omitted by default and visible when onBack provided
+ *   - end button is omitted when showEndButton=false or onEndGame missing
+ *   - back/end button presses fire their handlers
+ *   - score row exposes a screen-reader-friendly accessibility label
+ *   - score updates re-render to the new value
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+import { ScoreDisplay } from '../../../components/game/ScoreDisplay';
+
+jest.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      success: '#0A0',
+      error: '#A00',
+    },
+    colorScheme: 'light',
+  }),
+}));
+
+describe('ScoreDisplay', () => {
+  const defaultProps = {
+    homeTeamName: 'Hawks',
+    awayTeamName: 'Bulls',
+    homeScore: 10,
+    awayScore: 8,
+  };
+
+  it('renders both team names and scores', () => {
+    const { getByText } = render(<ScoreDisplay {...defaultProps} />);
+    expect(getByText('Hawks')).toBeTruthy();
+    expect(getByText('Bulls')).toBeTruthy();
+    expect(getByText('10')).toBeTruthy();
+    expect(getByText('8')).toBeTruthy();
+  });
+
+  it('renders the LIVE badge', () => {
+    const { getByText } = render(<ScoreDisplay {...defaultProps} />);
+    expect(getByText('LIVE')).toBeTruthy();
+  });
+
+  it('exposes a combined accessibility label for the score row', () => {
+    const { getByLabelText } = render(<ScoreDisplay {...defaultProps} />);
+    expect(getByLabelText('Score: Hawks 10, Bulls 8')).toBeTruthy();
+  });
+
+  it('does not render the back button when onBack is not provided', () => {
+    const { queryByLabelText } = render(<ScoreDisplay {...defaultProps} />);
+    expect(queryByLabelText('Go back')).toBeNull();
+  });
+
+  it('renders and dispatches the back button when onBack is provided', () => {
+    const onBack = jest.fn();
+    const { getByLabelText } = render(
+      <ScoreDisplay {...defaultProps} onBack={onBack} />
+    );
+    fireEvent.press(getByLabelText('Go back'));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders End button when onEndGame is provided and showEndButton is true (default)', () => {
+    const onEndGame = jest.fn();
+    const { getByLabelText, getByText } = render(
+      <ScoreDisplay {...defaultProps} onEndGame={onEndGame} />
+    );
+    expect(getByText('End')).toBeTruthy();
+    fireEvent.press(getByLabelText('End game'));
+    expect(onEndGame).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the End button when showEndButton is false even if onEndGame is set', () => {
+    const { queryByLabelText, queryByText } = render(
+      <ScoreDisplay
+        {...defaultProps}
+        onEndGame={jest.fn()}
+        showEndButton={false}
+      />
+    );
+    expect(queryByLabelText('End game')).toBeNull();
+    expect(queryByText('End')).toBeNull();
+  });
+
+  it('hides the End button when onEndGame is undefined', () => {
+    const { queryByLabelText } = render(
+      <ScoreDisplay {...defaultProps} showEndButton />
+    );
+    expect(queryByLabelText('End game')).toBeNull();
+  });
+
+  it('reflects updated scores on rerender', () => {
+    const { getByText, rerender, queryByText } = render(
+      <ScoreDisplay {...defaultProps} />
+    );
+    expect(getByText('10')).toBeTruthy();
+
+    rerender(<ScoreDisplay {...defaultProps} homeScore={12} awayScore={11} />);
+
+    expect(queryByText('10')).toBeNull();
+    expect(getByText('12')).toBeTruthy();
+    expect(getByText('11')).toBeTruthy();
+  });
+});

--- a/mobile/__tests__/components/game/ShotButtons.test.tsx
+++ b/mobile/__tests__/components/game/ShotButtons.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Tests for ShotButtons.
+ *
+ * Verifies the 2x2 grid of made/missed buttons for 2pt and 3pt:
+ *   - all four buttons are rendered with correct accessibility labels
+ *   - each button calls onShot with the right (points, made) tuple
+ *   - haptics fire (medium for made, light for miss)
+ *   - disabled blocks presses and shows the "Select a player first" hint
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import * as Haptics from 'expo-haptics';
+
+import { ShotButtons } from '../../../components/game/ShotButtons';
+
+jest.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      success: '#0A0',
+      error: '#A00',
+    },
+    colorScheme: 'light',
+  }),
+}));
+
+const mockedImpactAsync = Haptics.impactAsync as jest.Mock;
+
+describe('ShotButtons', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all four shot buttons with their accessibility labels', () => {
+    const { getByLabelText } = render(<ShotButtons onShot={jest.fn()} />);
+    expect(getByLabelText('2-point shot made')).toBeTruthy();
+    expect(getByLabelText('2-point shot missed')).toBeTruthy();
+    expect(getByLabelText('3-point shot made')).toBeTruthy();
+    expect(getByLabelText('3-point shot missed')).toBeTruthy();
+  });
+
+  it('renders MADE/MISS labels and point values on the buttons', () => {
+    const { getAllByText } = render(<ShotButtons onShot={jest.fn()} />);
+    expect(getAllByText('MADE').length).toBe(2);
+    expect(getAllByText('MISS').length).toBe(2);
+    expect(getAllByText('2PT').length).toBe(2);
+    expect(getAllByText('3PT').length).toBe(2);
+  });
+
+  it('calls onShot with (2, true) when the 2-point made button is pressed', () => {
+    const onShot = jest.fn();
+    const { getByLabelText } = render(<ShotButtons onShot={onShot} />);
+
+    fireEvent.press(getByLabelText('2-point shot made'));
+
+    expect(onShot).toHaveBeenCalledTimes(1);
+    expect(onShot).toHaveBeenCalledWith(2, true);
+  });
+
+  it('calls onShot with (2, false) when the 2-point missed button is pressed', () => {
+    const onShot = jest.fn();
+    const { getByLabelText } = render(<ShotButtons onShot={onShot} />);
+
+    fireEvent.press(getByLabelText('2-point shot missed'));
+
+    expect(onShot).toHaveBeenCalledWith(2, false);
+  });
+
+  it('calls onShot with (3, true) when the 3-point made button is pressed', () => {
+    const onShot = jest.fn();
+    const { getByLabelText } = render(<ShotButtons onShot={onShot} />);
+
+    fireEvent.press(getByLabelText('3-point shot made'));
+
+    expect(onShot).toHaveBeenCalledWith(3, true);
+  });
+
+  it('calls onShot with (3, false) when the 3-point missed button is pressed', () => {
+    const onShot = jest.fn();
+    const { getByLabelText } = render(<ShotButtons onShot={onShot} />);
+
+    fireEvent.press(getByLabelText('3-point shot missed'));
+
+    expect(onShot).toHaveBeenCalledWith(3, false);
+  });
+
+  it('triggers Medium haptic for a made shot and Light haptic for a miss', () => {
+    const { getByLabelText } = render(<ShotButtons onShot={jest.fn()} />);
+
+    fireEvent.press(getByLabelText('2-point shot made'));
+    expect(mockedImpactAsync).toHaveBeenLastCalledWith(
+      Haptics.ImpactFeedbackStyle.Medium
+    );
+
+    fireEvent.press(getByLabelText('2-point shot missed'));
+    expect(mockedImpactAsync).toHaveBeenLastCalledWith(
+      Haptics.ImpactFeedbackStyle.Light
+    );
+  });
+
+  it('does not call onShot when disabled', () => {
+    const onShot = jest.fn();
+    const { getByLabelText, getByText } = render(
+      <ShotButtons onShot={onShot} disabled />
+    );
+
+    fireEvent.press(getByLabelText('2-point shot made'));
+    fireEvent.press(getByLabelText('3-point shot missed'));
+
+    expect(onShot).not.toHaveBeenCalled();
+    expect(mockedImpactAsync).not.toHaveBeenCalled();
+    // Helper text appears in the disabled overlay.
+    expect(getByText('Select a player first')).toBeTruthy();
+  });
+
+  it('does not render the disabled hint when enabled', () => {
+    const { queryByText } = render(<ShotButtons onShot={jest.fn()} />);
+    expect(queryByText('Select a player first')).toBeNull();
+  });
+});

--- a/mobile/__tests__/components/game/StatButtons.test.tsx
+++ b/mobile/__tests__/components/game/StatButtons.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Tests for StatButtons.
+ *
+ * Verifies the five stat buttons (OREB, DREB, AST, STL, BLK) render with
+ * the right labels and accessibility text, dispatch their stat type when
+ * pressed, fire a Light haptic, and respect the disabled state.
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import * as Haptics from 'expo-haptics';
+
+import { StatButtons } from '../../../components/game/StatButtons';
+
+jest.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      success: '#0A0',
+      info: '#06C',
+      primary: '#22F',
+      warning: '#F90',
+      error: '#A00',
+      backgroundSecondary: '#EEE',
+      border: '#DDD',
+      textTertiary: '#999',
+    },
+    colorScheme: 'light',
+  }),
+}));
+
+const mockedImpactAsync = Haptics.impactAsync as jest.Mock;
+
+describe('StatButtons', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the section label and all five stat buttons', () => {
+    const { getByText } = render(<StatButtons onStat={jest.fn()} />);
+    expect(getByText('Other Stats')).toBeTruthy();
+    expect(getByText('OREB')).toBeTruthy();
+    expect(getByText('DREB')).toBeTruthy();
+    expect(getByText('AST')).toBeTruthy();
+    expect(getByText('STL')).toBeTruthy();
+    expect(getByText('BLK')).toBeTruthy();
+  });
+
+  it('exposes accessibility labels for each stat button', () => {
+    const { getByLabelText } = render(<StatButtons onStat={jest.fn()} />);
+    expect(getByLabelText('Record Off Reb')).toBeTruthy();
+    expect(getByLabelText('Record Def Reb')).toBeTruthy();
+    expect(getByLabelText('Record Assist')).toBeTruthy();
+    expect(getByLabelText('Record Steal')).toBeTruthy();
+    expect(getByLabelText('Record Block')).toBeTruthy();
+  });
+
+  it.each([
+    ['Record Off Reb', 'OREB'],
+    ['Record Def Reb', 'DREB'],
+    ['Record Assist', 'AST'],
+    ['Record Steal', 'STL'],
+    ['Record Block', 'BLK'],
+  ])('press on "%s" dispatches stat type %s', (label, type) => {
+    const onStat = jest.fn();
+    const { getByLabelText } = render(<StatButtons onStat={onStat} />);
+    fireEvent.press(getByLabelText(label));
+    expect(onStat).toHaveBeenCalledTimes(1);
+    expect(onStat).toHaveBeenCalledWith(type);
+  });
+
+  it('fires a Light haptic on each press', () => {
+    const { getByLabelText } = render(<StatButtons onStat={jest.fn()} />);
+    fireEvent.press(getByLabelText('Record Assist'));
+    expect(mockedImpactAsync).toHaveBeenCalledWith(
+      Haptics.ImpactFeedbackStyle.Light
+    );
+  });
+
+  it('does not invoke onStat or haptics when disabled, and shows the hint', () => {
+    const onStat = jest.fn();
+    const { getByLabelText, getByText } = render(
+      <StatButtons onStat={onStat} disabled />
+    );
+
+    fireEvent.press(getByLabelText('Record Off Reb'));
+    fireEvent.press(getByLabelText('Record Block'));
+
+    expect(onStat).not.toHaveBeenCalled();
+    expect(mockedImpactAsync).not.toHaveBeenCalled();
+    expect(getByText('Select a player first')).toBeTruthy();
+  });
+
+  it('does not show the disabled hint when enabled', () => {
+    const { queryByText } = render(<StatButtons onStat={jest.fn()} />);
+    expect(queryByText('Select a player first')).toBeNull();
+  });
+});

--- a/mobile/__tests__/components/game/UndoBanner.test.tsx
+++ b/mobile/__tests__/components/game/UndoBanner.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Tests for UndoBanner.
+ *
+ * Covers:
+ *   - returns null when not visible (component bails before rendering)
+ *   - renders the message + initial countdown when visible
+ *   - countdown decrements once per second
+ *   - calling onUndo runs when the UNDO button is pressed
+ *   - the visible→hidden transition unmounts the banner
+ */
+
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react-native';
+
+import { UndoBanner } from '../../../components/game/UndoBanner';
+
+jest.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      backgroundTertiary: '#FFF',
+      border: '#DDD',
+      text: '#111',
+      primary: '#06F',
+    },
+    colorScheme: 'light',
+  }),
+}));
+
+describe('UndoBanner', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('renders nothing when visible is false', () => {
+    const { toJSON } = render(
+      <UndoBanner visible={false} message="Removed shot" onUndo={jest.fn()} />
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders the message and the initial countdown when visible', () => {
+    const { getByText } = render(
+      <UndoBanner
+        visible
+        message="Removed last shot"
+        onUndo={jest.fn()}
+        duration={5}
+      />
+    );
+    expect(getByText('Removed last shot')).toBeTruthy();
+    expect(getByText('UNDO (5s)')).toBeTruthy();
+  });
+
+  it('honours a custom duration in the initial countdown label', () => {
+    const { getByText } = render(
+      <UndoBanner visible message="x" onUndo={jest.fn()} duration={8} />
+    );
+    expect(getByText('UNDO (8s)')).toBeTruthy();
+  });
+
+  it('decrements the countdown every second', () => {
+    const { getByText } = render(
+      <UndoBanner visible message="x" onUndo={jest.fn()} duration={3} />
+    );
+    expect(getByText('UNDO (3s)')).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(getByText('UNDO (2s)')).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(getByText('UNDO (1s)')).toBeTruthy();
+  });
+
+  it('calls onUndo when the UNDO button is pressed', () => {
+    const onUndo = jest.fn();
+    const { getByText } = render(
+      <UndoBanner visible message="x" onUndo={onUndo} duration={5} />
+    );
+    fireEvent.press(getByText('UNDO (5s)'));
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it('unmounts content when toggled from visible to hidden', () => {
+    const { rerender, queryByText } = render(
+      <UndoBanner visible message="hello" onUndo={jest.fn()} duration={5} />
+    );
+    expect(queryByText('hello')).toBeTruthy();
+
+    rerender(
+      <UndoBanner visible={false} message="hello" onUndo={jest.fn()} duration={5} />
+    );
+    expect(queryByText('hello')).toBeNull();
+  });
+});

--- a/mobile/__tests__/hooks/useAnnouncements.runtime.test.tsx
+++ b/mobile/__tests__/hooks/useAnnouncements.runtime.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Runtime tests for useAnnouncements hooks.
+ *
+ * Exercises actual React Query hook execution: query function calls,
+ * the team-scoped queryKey shape, and that mutations invalidate the
+ * correct cache.
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+
+import {
+  useAnnouncements,
+  useCreateAnnouncement,
+  announcementKeys,
+} from '../../hooks/useAnnouncements';
+import { apiClient } from '../../services/api-client';
+import { createQueryWrapper } from '../utils/queryWrapper';
+
+const mockedGet = apiClient.get as jest.Mock;
+const mockedPost = apiClient.post as jest.Mock;
+
+describe('useAnnouncements runtime', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('announcementKeys', () => {
+    it('builds a stable list root key', () => {
+      expect(announcementKeys.all).toEqual(['announcements']);
+    });
+
+    it('namespaces team-scoped keys under the list root', () => {
+      expect(announcementKeys.team('t1')).toEqual(['announcements', 't1']);
+    });
+  });
+
+  describe('useAnnouncements query', () => {
+    it('fetches announcements for a team and returns the payload', async () => {
+      const payload = {
+        success: true,
+        announcements: [
+          {
+            id: 'a1',
+            teamId: 't1',
+            authorId: 'u1',
+            title: 'Practice Cancelled',
+            body: 'No practice tonight',
+            createdAt: '2026-04-19T00:00:00Z',
+            author: { id: 'u1', name: 'Coach' },
+          },
+        ],
+        total: 1,
+      };
+      mockedGet.mockResolvedValueOnce({ data: payload });
+
+      const { wrapper } = createQueryWrapper();
+      const { result } = renderHook(() => useAnnouncements('t1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(payload);
+      expect(mockedGet).toHaveBeenCalledWith('/teams/t1/announcements');
+    });
+
+    it('is disabled when teamId is empty (no fetch)', () => {
+      const { wrapper } = createQueryWrapper();
+      const { result } = renderHook(() => useAnnouncements(''), { wrapper });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(mockedGet).not.toHaveBeenCalled();
+    });
+
+    it('surfaces errors when the request fails', async () => {
+      mockedGet.mockRejectedValueOnce(new Error('network down'));
+      const { wrapper } = createQueryWrapper();
+      const { result } = renderHook(() => useAnnouncements('t1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect((result.current.error as Error).message).toBe('network down');
+    });
+  });
+
+  describe('useCreateAnnouncement mutation', () => {
+    it('posts to the team-scoped endpoint and returns the announcement', async () => {
+      const announcement = {
+        id: 'a1',
+        teamId: 't1',
+        authorId: 'u1',
+        title: 'Game Time',
+        body: 'Friday 7pm',
+        createdAt: '2026-04-19T00:00:00Z',
+        author: { id: 'u1', name: 'Coach' },
+      };
+      mockedPost.mockResolvedValueOnce({
+        data: { success: true, announcement },
+      });
+
+      const { wrapper } = createQueryWrapper();
+      const { result } = renderHook(() => useCreateAnnouncement(), { wrapper });
+
+      let returned: unknown;
+      await act(async () => {
+        returned = await result.current.mutateAsync({
+          teamId: 't1',
+          data: { title: 'Game Time', body: 'Friday 7pm' },
+        });
+      });
+
+      expect(mockedPost).toHaveBeenCalledWith('/teams/t1/announcements', {
+        title: 'Game Time',
+        body: 'Friday 7pm',
+      });
+      expect(returned).toEqual(announcement);
+    });
+
+    it('invalidates only the team-scoped announcements cache on success', async () => {
+      mockedPost.mockResolvedValueOnce({
+        data: {
+          success: true,
+          announcement: {
+            id: 'a1',
+            teamId: 't1',
+            authorId: 'u1',
+            title: 't',
+            body: 'b',
+            createdAt: '2026-04-19T00:00:00Z',
+            author: { id: 'u1', name: 'Coach' },
+          },
+        },
+      });
+
+      const { wrapper, client } = createQueryWrapper();
+      const invalidateSpy = jest.spyOn(client, 'invalidateQueries');
+      const { result } = renderHook(() => useCreateAnnouncement(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          teamId: 't1',
+          data: { title: 't', body: 'b' },
+        });
+      });
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: announcementKeys.team('t1'),
+      });
+      // Should NOT broadly invalidate the all-announcements root, only the team key.
+      const calls = invalidateSpy.mock.calls.map((c) =>
+        JSON.stringify(c[0]?.queryKey)
+      );
+      expect(calls).toContain(JSON.stringify(['announcements', 't1']));
+    });
+
+    it('surfaces errors from the API', async () => {
+      mockedPost.mockRejectedValueOnce(new Error('forbidden'));
+      const { wrapper } = createQueryWrapper();
+      const { result } = renderHook(() => useCreateAnnouncement(), { wrapper });
+
+      await expect(
+        act(async () => {
+          await result.current.mutateAsync({
+            teamId: 't1',
+            data: { title: 't', body: 'b' },
+          });
+        })
+      ).rejects.toThrow('forbidden');
+    });
+  });
+});

--- a/mobile/__tests__/hooks/useNotifications.runtime.test.tsx
+++ b/mobile/__tests__/hooks/useNotifications.runtime.test.tsx
@@ -1,0 +1,335 @@
+/**
+ * Runtime tests for useNotificationSetup.
+ *
+ * Covers the full effect path:
+ *   - bails when no auth token
+ *   - bails when not running on a physical device
+ *   - bails when permissions are denied
+ *   - registers the push token with the backend on success
+ *   - swallows backend errors silently
+ *   - subscribes to tap responses and routes by data payload
+ *   - cleans up the subscription on unmount
+ *
+ * Mocks expo-notifications, expo-device, expo-constants, expo-router, and
+ * the apiClient. The auth-store is exercised via its real Zustand setter
+ * to flip `accessToken` between renders.
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+import { Platform } from 'react-native';
+
+import { apiClient } from '../../services/api-client';
+import { useAuthStore } from '../../store/auth-store';
+
+const mockedPost = apiClient.post as jest.Mock;
+
+// expo-device — control isDevice flag per test via a getter so mutation
+// from test bodies actually takes effect when the hook reads it.
+const mockDeviceState = { isDevice: true };
+jest.mock('expo-device', () => ({
+  get isDevice() {
+    return mockDeviceState.isDevice;
+  },
+}));
+
+// expo-constants — provide a deterministic projectId.
+jest.mock('expo-constants', () => ({
+  __esModule: true,
+  default: {
+    expoConfig: {
+      extra: {
+        eas: { projectId: 'test-project-id' },
+      },
+    },
+  },
+}));
+
+// expo-notifications — capture the response listener handler so tests can
+// invoke it directly to simulate a notification tap. We stash state on a
+// global-ish object (var hoisted, mock-prefixed name allowed by jest) to
+// avoid the "out of scope variable" guard.
+const mockNotificationsState: {
+  removeMock: jest.Mock;
+  lastHandler: ((response: unknown) => void) | null;
+} = {
+  removeMock: jest.fn(),
+  lastHandler: null,
+};
+jest.mock('expo-notifications', () => ({
+  setNotificationHandler: jest.fn(),
+  getPermissionsAsync: jest.fn(),
+  requestPermissionsAsync: jest.fn(),
+  getExpoPushTokenAsync: jest.fn(),
+  addNotificationResponseReceivedListener: jest.fn((handler) => {
+    mockNotificationsState.lastHandler = handler;
+    return { remove: mockNotificationsState.removeMock };
+  }),
+}));
+
+// expo-router — capture the push() function so tests can assert routing.
+const mockRouter = {
+  push: jest.fn(),
+};
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    push: mockRouter.push,
+    replace: jest.fn(),
+    back: jest.fn(),
+    canGoBack: jest.fn(() => true),
+  }),
+}));
+
+import * as Notifications from 'expo-notifications';
+import { useNotificationSetup } from '../../hooks/useNotifications';
+
+const mockedGetPermissions = Notifications.getPermissionsAsync as jest.Mock;
+const mockedRequestPermissions =
+  Notifications.requestPermissionsAsync as jest.Mock;
+const mockedGetToken = Notifications.getExpoPushTokenAsync as jest.Mock;
+const mockedAddListener =
+  Notifications.addNotificationResponseReceivedListener as jest.Mock;
+
+// Helper: set authenticated state directly (bypasses analytics in setUser).
+function setAuthenticated(token: string | null) {
+  useAuthStore.setState({
+    accessToken: token,
+    isAuthenticated: token !== null,
+    isLoading: false,
+  });
+}
+
+describe('useNotificationSetup runtime', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNotificationsState.lastHandler = null;
+    setAuthenticated(null);
+    // Default device flag — physical device.
+    mockDeviceState.isDevice = true;
+    // Default to platform iOS.
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      get: () => 'ios',
+    });
+  });
+
+  it('does nothing when there is no access token', () => {
+    renderHook(() => useNotificationSetup());
+
+    expect(mockedGetPermissions).not.toHaveBeenCalled();
+    expect(mockedRequestPermissions).not.toHaveBeenCalled();
+    expect(mockedAddListener).not.toHaveBeenCalled();
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('skips token registration on a non-device (simulator) but still subscribes to taps', async () => {
+    mockDeviceState.isDevice = false;
+    setAuthenticated('jwt-token');
+
+    renderHook(() => useNotificationSetup());
+
+    // The listener subscribe is synchronous within the effect.
+    expect(mockedAddListener).toHaveBeenCalledTimes(1);
+    // Token registration short-circuits before requesting permissions.
+    await waitFor(() => {
+      expect(mockedGetPermissions).not.toHaveBeenCalled();
+    });
+    expect(mockedRequestPermissions).not.toHaveBeenCalled();
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('does not request a token when permissions are denied', async () => {
+    setAuthenticated('jwt-token');
+    mockedGetPermissions.mockResolvedValueOnce({ status: 'denied' });
+    mockedRequestPermissions.mockResolvedValueOnce({ status: 'denied' });
+
+    renderHook(() => useNotificationSetup());
+
+    await waitFor(() => {
+      expect(mockedRequestPermissions).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedGetToken).not.toHaveBeenCalled();
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('skips the request prompt when permissions are already granted', async () => {
+    setAuthenticated('jwt-token');
+    mockedGetPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockedGetToken.mockResolvedValueOnce({ data: 'ExponentPushToken[abc]' });
+    mockedPost.mockResolvedValueOnce({ data: { success: true } });
+
+    renderHook(() => useNotificationSetup());
+
+    await waitFor(() => {
+      expect(mockedPost).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedRequestPermissions).not.toHaveBeenCalled();
+    expect(mockedGetToken).toHaveBeenCalledWith({ projectId: 'test-project-id' });
+    expect(mockedPost).toHaveBeenCalledWith('/auth/push-token', {
+      token: 'ExponentPushToken[abc]',
+      platform: 'ios',
+    });
+  });
+
+  it('registers the token after prompting when status starts as undetermined', async () => {
+    setAuthenticated('jwt-token');
+    mockedGetPermissions.mockResolvedValueOnce({ status: 'undetermined' });
+    mockedRequestPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockedGetToken.mockResolvedValueOnce({ data: 'ExponentPushToken[xyz]' });
+    mockedPost.mockResolvedValueOnce({ data: { success: true } });
+
+    renderHook(() => useNotificationSetup());
+
+    await waitFor(() => {
+      expect(mockedPost).toHaveBeenCalledWith('/auth/push-token', {
+        token: 'ExponentPushToken[xyz]',
+        platform: 'ios',
+      });
+    });
+  });
+
+  it('reports the android platform when running on android', async () => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      get: () => 'android',
+    });
+    setAuthenticated('jwt-token');
+    mockedGetPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockedGetToken.mockResolvedValueOnce({ data: 'tok' });
+    mockedPost.mockResolvedValueOnce({ data: { success: true } });
+
+    renderHook(() => useNotificationSetup());
+
+    await waitFor(() => {
+      expect(mockedPost).toHaveBeenCalledWith('/auth/push-token', {
+        token: 'tok',
+        platform: 'android',
+      });
+    });
+  });
+
+  it('silently swallows backend failures when registering the token', async () => {
+    setAuthenticated('jwt-token');
+    mockedGetPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockedGetToken.mockResolvedValueOnce({ data: 'tok' });
+    mockedPost.mockRejectedValueOnce(new Error('500'));
+
+    // Should not throw — register failure is intentionally swallowed.
+    renderHook(() => useNotificationSetup());
+
+    await waitFor(() => {
+      expect(mockedPost).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('routes to the game screen when a notification with gameId is tapped', async () => {
+    setAuthenticated('jwt-token');
+    mockedGetPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockedGetToken.mockResolvedValueOnce({ data: 'tok' });
+    mockedPost.mockResolvedValueOnce({ data: { success: true } });
+
+    renderHook(() => useNotificationSetup());
+
+    await waitFor(() => expect(mockNotificationsState.lastHandler).not.toBeNull());
+
+    act(() => {
+      mockNotificationsState.lastHandler?.({
+        notification: { request: { content: { data: { gameId: 'g1' } } } },
+      });
+    });
+
+    expect(mockRouter.push).toHaveBeenCalledWith('/games/g1');
+  });
+
+  it('routes to the team screen when a notification with teamId is tapped', async () => {
+    setAuthenticated('jwt-token');
+    mockedGetPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockedGetToken.mockResolvedValueOnce({ data: 'tok' });
+    mockedPost.mockResolvedValueOnce({ data: { success: true } });
+
+    renderHook(() => useNotificationSetup());
+
+    await waitFor(() => expect(mockNotificationsState.lastHandler).not.toBeNull());
+
+    act(() => {
+      mockNotificationsState.lastHandler?.({
+        notification: { request: { content: { data: { teamId: 't1' } } } },
+      });
+    });
+
+    expect(mockRouter.push).toHaveBeenCalledWith('/teams/t1');
+  });
+
+  it('prefers gameId routing when both gameId and teamId are present', async () => {
+    setAuthenticated('jwt-token');
+    mockedGetPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockedGetToken.mockResolvedValueOnce({ data: 'tok' });
+    mockedPost.mockResolvedValueOnce({ data: { success: true } });
+
+    renderHook(() => useNotificationSetup());
+
+    await waitFor(() => expect(mockNotificationsState.lastHandler).not.toBeNull());
+
+    act(() => {
+      mockNotificationsState.lastHandler?.({
+        notification: {
+          request: { content: { data: { gameId: 'g1', teamId: 't1' } } },
+        },
+      });
+    });
+
+    expect(mockRouter.push).toHaveBeenCalledTimes(1);
+    expect(mockRouter.push).toHaveBeenCalledWith('/games/g1');
+  });
+
+  it('does not navigate when the notification carries no routing data', async () => {
+    setAuthenticated('jwt-token');
+    mockedGetPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockedGetToken.mockResolvedValueOnce({ data: 'tok' });
+    mockedPost.mockResolvedValueOnce({ data: { success: true } });
+
+    renderHook(() => useNotificationSetup());
+
+    await waitFor(() => expect(mockNotificationsState.lastHandler).not.toBeNull());
+
+    act(() => {
+      mockNotificationsState.lastHandler?.({
+        notification: { request: { content: { data: {} } } },
+      });
+    });
+
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+
+  it('handles a notification with a missing data field without crashing', async () => {
+    setAuthenticated('jwt-token');
+    mockedGetPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockedGetToken.mockResolvedValueOnce({ data: 'tok' });
+    mockedPost.mockResolvedValueOnce({ data: { success: true } });
+
+    renderHook(() => useNotificationSetup());
+
+    await waitFor(() => expect(mockNotificationsState.lastHandler).not.toBeNull());
+
+    act(() => {
+      mockNotificationsState.lastHandler?.({
+        notification: { request: { content: {} } },
+      });
+    });
+
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+
+  it('removes the response subscription on unmount', async () => {
+    setAuthenticated('jwt-token');
+    mockedGetPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockedGetToken.mockResolvedValueOnce({ data: 'tok' });
+    mockedPost.mockResolvedValueOnce({ data: { success: true } });
+
+    const { unmount } = renderHook(() => useNotificationSetup());
+
+    await waitFor(() => expect(mockedAddListener).toHaveBeenCalledTimes(1));
+
+    unmount();
+    expect(mockNotificationsState.removeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -23,15 +23,21 @@ module.exports = {
   // useGameEvents, useSeasons, useStats, useInvitations via a new
   // QueryClient test wrapper; covered services/sentry.ts; added StatRow
   // + SeasonAverages component tests. Observed: stmts 48.94 /
-  // branches 49.24 / funcs 47.56 / lines 48.81. Thresholds set ~1pt below
-  // actuals to tolerate trivial churn. These must only ratchet upward —
-  // see issue #51.
+  // branches 49.24 / funcs 47.56 / lines 48.81.
+  // Pass 3 (2026-04-19): added React-Query runtime tests for
+  // useAnnouncements + useNotifications (full effect path: device gating,
+  // permission flow, push-token registration, deep-link routing on tap),
+  // and component tests for game/OpponentScoreButtons, ShotButtons,
+  // StatButtons, UndoBanner, ScoreDisplay, PlayerRoster. Observed:
+  // stmts 62.94 / branches 59.72 / funcs 60.48 / lines 62.77.
+  // Thresholds set ~1pt below actuals to tolerate trivial churn. These
+  // must only ratchet upward — see issue #51.
   coverageThreshold: {
     global: {
-      branches: 48,
-      functions: 46,
-      lines: 47,
-      statements: 47,
+      branches: 58,
+      functions: 59,
+      lines: 61,
+      statements: 61,
     },
   },
   moduleNameMapper: {


### PR DESCRIPTION
## Summary

Mobile coverage pass 3 toward the GA target of 70/60/70/70 (issue #51). Adds 70 tests across 8 new suites; raises floors. No source changes.

## Coverage

| Metric | Before | After | Delta | Floor (new) | GA target |
|---|---|---|---|---|---|
| Statements | 48.94% | **62.94%** | +14.00 | 61 | 70 |
| Branches | 49.24% | **59.72%** | +10.48 | 58 | 60 |
| Functions | 47.56% | **60.48%** | +12.92 | 59 | 70 |
| Lines | 48.81% | **62.77%** | +13.96 | 61 | 70 |

Branches floor (58) is now within 2pt of the GA target.

## New tests

- `__tests__/hooks/useAnnouncements.runtime.test.tsx` — 8 tests
- `__tests__/hooks/useNotifications.runtime.test.tsx` — 13 tests (device gating, permission flow, push-token registration, deep-link routing on tap)
- `__tests__/components/game/OpponentScoreButtons.test.tsx` — 6 tests
- `__tests__/components/game/ShotButtons.test.tsx` — 9 tests
- `__tests__/components/game/StatButtons.test.tsx` — 10 tests
- `__tests__/components/game/UndoBanner.test.tsx` — 6 tests
- `__tests__/components/game/ScoreDisplay.test.tsx` — 9 tests
- `__tests__/components/game/PlayerRoster.test.tsx` — 9 tests

Reuses `__tests__/utils/queryWrapper.tsx` from pass 2.

## Remaining for the next pass

- `components/game/EventTimeline.tsx` (229 LoC, 0%) — ~2-3 stmt pts
- `components/game/GameCard.tsx` (264 LoC, 0%) — ~3 stmt pts
- File-based router screens under `app/games/` still uncovered

After those, statements/lines/functions should be within striking distance of 70.

## Test plan

- [x] `npm test -- --coverage` passes locally (381/36, exit 0)
- [x] `npm run type-check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)