### PR TITLE
chore(deps): bump mobile patch deps (2026-05-02)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -17,7 +17,7 @@
         "@react-native-community/datetimepicker": "^8.6.0",
         "@sentry/react-native": "^8.9.1",
         "@tanstack/react-query": "^5.100.1",
-        "axios": "^1.15.2",
+        "axios": "^1.16.0",
         "babel-preset-expo": "^55.0.19",
         "expo": "^55.0.17",
         "expo-blur": "~55.0.14",
@@ -7886,12 +7886,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -24,7 +24,7 @@
     "@react-native-community/datetimepicker": "^8.6.0",
     "@sentry/react-native": "^8.9.1",
     "@tanstack/react-query": "^5.100.1",
-    "axios": "^1.15.2",
+    "axios": "^1.16.0",
     "babel-preset-expo": "^55.0.19",
     "expo": "^55.0.17",
     "expo-blur": "~55.0.14",


### PR DESCRIPTION
Lockfile-only patch/minor bump for the mobile app, within the existing caret range. No CVE references. Eligible for auto-merge per the [Daily Upgrade Scan](../blob/main/docs/automation/daily-upgrade-scan.md) routine.

## Versions

| Package | From | To |
| --- | --- | --- |
| `axios` | 1.15.2 | 1.16.0 |

> Note: `@sentry/react-native` (8.9.1 → 8.10.0) is also patch-eligible today but is skipped here for idempotency — still pending in open PR #87. `@tanstack/react-query` (5.100.1 → 5.100.8) and `i18next` (26.0.7 → 26.0.8) are skipped for the same reason — still pending in open PR #86. `eas-cli` (18.8.1 → 18.9.1), `expo` (55.0.17 → 55.0.19), `expo-notifications` (55.0.20 → 55.0.22), `react-i18next` (17.0.4 → 17.0.6), and `zod` (4.3.6 → 4.4.2) are skipped for the same reason — still pending in open PR #88.

## CVE references

None — this batch is patch-version churn, not a security override.

## Quality gates

- `npm run type-check` — clean
- `npm test` — 36 suites / 381 tests pass
- `npx expo export --platform ios` — success
- Diff guard — only `mobile/package.json` and `mobile/package-lock.json`

Generated by the Daily Upgrade Scan routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_014fHsNLD36bykgwu9E5Y6e3)_