### PR TITLE
chore(deps): bump mobile patch deps (2026-05-05)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -18,14 +18,14 @@
         "@sentry/react-native": "^8.10.0",
         "@tanstack/react-query": "^5.100.9",
         "axios": "^1.16.0",
-        "babel-preset-expo": "^55.0.19",
-        "expo": "^55.0.19",
+        "babel-preset-expo": "^55.0.20",
+        "expo": "^55.0.21",
         "expo-blur": "~55.0.14",
         "expo-constants": "^55.0.15",
         "expo-device": "^55.0.15",
         "expo-font": "~55.0.6",
         "expo-haptics": "~55.0.14",
-        "expo-image-picker": "^55.0.19",
+        "expo-image-picker": "^55.0.20",
         "expo-linear-gradient": "~55.0.13",
         "expo-linking": "^55.0.14",
         "expo-localization": "~55.0.13",
@@ -49,7 +49,7 @@
         "react-native-svg": "15.15.3",
         "react-native-worklets": "^0.7.4",
         "zod": "^4.4.3",
-        "zustand": "^5.0.9"
+        "zustand": "^5.0.13"
       },
       "devDependencies": {
         "@testing-library/react-native": "^13.3.3",
@@ -1715,9 +1715,9 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "55.0.27",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-55.0.27.tgz",
-      "integrity": "sha512-FF/qWyHikqvVd5GBDiLII2PRgToNGz5MjxHw76a7aufbe5kCRpAqAy7HRoio1PlF5g9UIYnFjs333a3fWTlgMw==",
+      "version": "55.0.28",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-55.0.28.tgz",
+      "integrity": "sha512-N3ZdMc5h9BZE2jn9O8xR2umJij+C7h1BMhZATw37zuTbh/JIcqBdfY5xRbpnMGw0VvNdK15nh89NYc8SzLUtow==",
       "license": "MIT",
       "dependencies": {
         "@expo/code-signing-certificates": "^0.0.6",
@@ -1729,7 +1729,7 @@
         "@expo/json-file": "^10.0.13",
         "@expo/log-box": "55.0.11",
         "@expo/metro": "~55.1.1",
-        "@expo/metro-config": "~55.0.18",
+        "@expo/metro-config": "~55.0.19",
         "@expo/osascript": "^2.4.2",
         "@expo/package-manager": "^1.10.4",
         "@expo/plist": "^0.5.2",
@@ -3310,9 +3310,9 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "55.0.18",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-55.0.18.tgz",
-      "integrity": "sha512-XT7YHdQsUjdun0n4cyE5iXIyncDERIG4WesMBRUClr1RAurPwyg95BrbOBpq3E3uvwSBrAGfhu1w8VADqP4ZTQ==",
+      "version": "55.0.19",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-55.0.19.tgz",
+      "integrity": "sha512-tOeSR0w81F4wJxLm77Ee1FkaUUOfx7DuYgpoaOCBqODJOODX5fTydLjQPvezMQtFJubh2XWM9+4QoScqLTWbig==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -7917,9 +7917,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "55.0.19",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-55.0.19.tgz",
-      "integrity": "sha512-IaxT7xremfrW2HqtG7gWI7TUSJke/V+zDW1whLpmO06ZdKOfB5Qup7oICqBWqfbcBW3h57llWOMAn1cycvbsgQ==",
+      "version": "55.0.20",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-55.0.20.tgz",
+      "integrity": "sha512-wMSaNtpPrH7+QNBF7HOCfO6WgmdXO84JEdqMhFxWc1CvwcWTvWwgc4yQustW1q1kG5ZE/dHgHkmHPlvVY5apMQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.20.5",
@@ -7949,7 +7949,7 @@
       "peerDependencies": {
         "@babel/runtime": "^7.20.0",
         "expo": "*",
-        "expo-widgets": "^55.0.15",
+        "expo-widgets": "^55.0.16",
         "react-refresh": ">=0.14.0 <1.0.0"
       },
       "peerDependenciesMeta": {
@@ -9724,13 +9724,13 @@
       "license": "MIT"
     },
     "node_modules/expo": {
-      "version": "55.0.19",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-55.0.19.tgz",
-      "integrity": "sha512-8nTbChg2vy7aNsX5F7KiSb552YP7dc4eD89+UjCKlFPQg4Dw7RyjYuXgFBU7ADw2JjTHl848jFLyT6nvqNROgg==",
+      "version": "55.0.21",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-55.0.21.tgz",
+      "integrity": "sha512-FgZuKoUUwCKzHeugYefaYyZG3w/q4B7TwvfJUX4v9/k3kNChlgMXvKcd3hpGdCryx75YGVxhYxDnGN5oU5fddw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "55.0.27",
+        "@expo/cli": "55.0.28",
         "@expo/config": "~55.0.15",
         "@expo/config-plugins": "~55.0.8",
         "@expo/devtools": "55.0.2",
@@ -9738,16 +9738,16 @@
         "@expo/local-build-cache-provider": "55.0.11",
         "@expo/log-box": "55.0.11",
         "@expo/metro": "~55.1.1",
-        "@expo/metro-config": "55.0.18",
+        "@expo/metro-config": "55.0.19",
         "@expo/vector-icons": "^15.0.2",
         "@ungap/structured-clone": "^1.3.0",
-        "babel-preset-expo": "~55.0.19",
+        "babel-preset-expo": "~55.0.20",
         "expo-asset": "~55.0.16",
         "expo-constants": "~55.0.15",
         "expo-file-system": "~55.0.17",
         "expo-font": "~55.0.6",
         "expo-keep-awake": "~55.0.7",
-        "expo-modules-autolinking": "55.0.19",
+        "expo-modules-autolinking": "55.0.20",
         "expo-modules-core": "55.0.24",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
@@ -10010,9 +10010,9 @@
       }
     },
     "node_modules/expo-image-picker": {
-      "version": "55.0.19",
-      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-55.0.19.tgz",
-      "integrity": "sha512-PqOOfRz7+hbB9IFN0LfNxpJJwuPlUG0Abr0qM3Wc61OJ7FFyuKJ50QJ/fFItzSuoXifET1YIFBiXx5nA8Gkinw==",
+      "version": "55.0.20",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-55.0.20.tgz",
+      "integrity": "sha512-lfWt/0rPWdKz8AdDEGmGHZIJSNlVc720Dlx5bfou10FU16ZV5wAbTU63nm2jkXd8hbXke4a/2Ha1dzxCVA+LQQ==",
       "license": "MIT",
       "dependencies": {
         "expo-image-loader": "~55.0.0"
@@ -10088,9 +10088,9 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "55.0.19",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-55.0.19.tgz",
-      "integrity": "sha512-rHO1NZC/bxcKTLzkn6WYm9ErzS6qp7Kgb1NM2YxXJAYRWHwW/M7NZXyj6swWiKxyhRpcdoppRpjrz1sBuYGAjg==",
+      "version": "55.0.20",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-55.0.20.tgz",
+      "integrity": "sha512-gg9eQJpa5yuyxnxubm3yBN9xKfieGgoBmYXGWI7kW0rWqk7OU440tRsZ1IOQunndhHeB/ZbRy7WpkyEBbaOR3Q==",
       "license": "MIT",
       "dependencies": {
         "@expo/require-utils": "^55.0.4",
@@ -18453,9 +18453,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
-      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -25,14 +25,14 @@
     "@sentry/react-native": "^8.10.0",
     "@tanstack/react-query": "^5.100.9",
     "axios": "^1.16.0",
-    "babel-preset-expo": "^55.0.19",
-    "expo": "^55.0.19",
+    "babel-preset-expo": "^55.0.20",
+    "expo": "^55.0.21",
     "expo-blur": "~55.0.14",
     "expo-constants": "^55.0.15",
     "expo-device": "^55.0.15",
     "expo-font": "~55.0.6",
     "expo-haptics": "~55.0.14",
-    "expo-image-picker": "^55.0.19",
+    "expo-image-picker": "^55.0.20",
     "expo-linear-gradient": "~55.0.13",
     "expo-linking": "^55.0.14",
     "expo-localization": "~55.0.13",
@@ -56,7 +56,7 @@
     "react-native-svg": "15.15.3",
     "react-native-worklets": "^0.7.4",
     "zod": "^4.4.3",
-    "zustand": "^5.0.9"
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@testing-library/react-native": "^13.3.3",


### PR DESCRIPTION
In-caret bumps picked up by the [Daily Upgrade Scan](../blob/main/docs/automation/daily-upgrade-scan.md) routine. All within Expo SDK 55.

## Versions

| Package             | Before    | After     |
| ------------------- | --------- | --------- |
| `expo`              | 55.0.19   | 55.0.21   |
| `expo-image-picker` | 55.0.19   | 55.0.20   |
| `babel-preset-expo` | 55.0.19   | 55.0.20   |
| `zustand`           | 5.0.12    | 5.0.13    |

## CVE references

None — no Dependabot alerts triggered these bumps. Routine-driven in-caret patch refresh only.

## Quality gates

- `npm run type-check` — clean
- `npm test` — 36 suites / 381 tests pass
- `npx expo export --platform ios --output-dir /tmp/v` — bundle exported successfully
- Diff guard: only `mobile/package.json` + `mobile/package-lock.json` modified

Auto-merge will fire once required CI checks are green.

https://claude.ai/code/session_01D6GTAmMaisguRmX2zeJBL6


---
_Generated by [Claude Code](https://claude.ai/code/session_01D6GTAmMaisguRmX2zeJBL6)_