### PR TITLE
chore(deps): bump mobile patch deps (2026-05-14)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mobile",
       "version": "1.0.0",
       "dependencies": {
-        "@amplitude/analytics-react-native": "^1.5.37",
+        "@amplitude/analytics-react-native": "^1.5.53",
         "@amplitude/analytics-types": "^2.11.1",
         "@expo-google-fonts/inter": "^0.4.2",
         "@expo-google-fonts/oswald": "^0.4.2",
@@ -17,7 +17,7 @@
         "@react-native-community/datetimepicker": "^8.6.0",
         "@sentry/react-native": "^8.11.1",
         "@tanstack/react-query": "^5.100.10",
-        "axios": "^1.16.0",
+        "axios": "^1.16.1",
         "babel-preset-expo": "^55.0.21",
         "expo": "^55.0.24",
         "expo-blur": "~55.0.14",
@@ -84,9 +84,9 @@
       "license": "MIT"
     },
     "node_modules/@amplitude/analytics-core": {
-      "version": "2.41.5",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.41.5.tgz",
-      "integrity": "sha512-RImmiQTtkwYPuNRsCvqOpz/QbBEt1H4GmYbiiwIXzgvoiIKTvE5h+yqkMGAKAb8Su9lA6cIWqiYucp605a0PkQ==",
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.48.1.tgz",
+      "integrity": "sha512-6ltecomnZc9z1AUE59orcoLYii0gPoVBBoI4qoMGXw2lsxFh35zx32LPrXO3ezFkTE71CS44AzwaBFsSxQWRuw==",
       "license": "MIT",
       "dependencies": {
         "@amplitude/analytics-connector": "^1.6.4",
@@ -97,12 +97,12 @@
       }
     },
     "node_modules/@amplitude/analytics-react-native": {
-      "version": "1.5.52",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.5.52.tgz",
-      "integrity": "sha512-Nz2u+oCGOPAMl00zg074Q5Jm5UTUrstyTA8zHXFDe65N/DNFYWKEKvwnNQvn2FIkaNUCORIvjtwMIzxRzNRRww==",
+      "version": "1.5.53",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.5.53.tgz",
+      "integrity": "sha512-C1KFraq3xuP+hcCS7krcLdf5OebAdarHTJ2fNe9XuwAQERWie4A4GnHmPmW6Vtz5LpUhAiiEjS8Ugfa/sTQs2g==",
       "license": "MIT",
       "dependencies": {
-        "@amplitude/analytics-core": "2.41.5",
+        "@amplitude/analytics-core": "2.48.1",
         "@amplitude/ua-parser-js": "^0.7.31",
         "@react-native-async-storage/async-storage": "^1.17.11",
         "tslib": "^2.4.1"
@@ -7422,7 +7422,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -7647,13 +7646,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -11582,7 +11582,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,7 +15,7 @@
     "eas-build-on-success": "node scripts/sentry-upload-sourcemaps.js"
   },
   "dependencies": {
-    "@amplitude/analytics-react-native": "^1.5.37",
+    "@amplitude/analytics-react-native": "^1.5.53",
     "@amplitude/analytics-types": "^2.11.1",
     "@expo-google-fonts/inter": "^0.4.2",
     "@expo-google-fonts/oswald": "^0.4.2",
@@ -24,7 +24,7 @@
     "@react-native-community/datetimepicker": "^8.6.0",
     "@sentry/react-native": "^8.11.1",
     "@tanstack/react-query": "^5.100.10",
-    "axios": "^1.16.0",
+    "axios": "^1.16.1",
     "babel-preset-expo": "^55.0.21",
     "expo": "^55.0.24",
     "expo-blur": "~55.0.14",


### PR DESCRIPTION
Daily Upgrade Scan auto-fix batch (mobile caret-range patches).

| Package | From | To |
| --- | --- | --- |
| @amplitude/analytics-react-native | 1.5.52 | 1.5.53 |
| axios | 1.16.0 | 1.16.1 |

No CVE alerts paired with this batch.

## Quality gates

- `npm run type-check` ✅
- `npm test` ✅ (381 passed across 36 suites)
- `npx expo export --platform ios` ✅

Auto-merge enabled (squash). Generated by the Daily Upgrade Scan routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGtzje4QMRDnfMJapKcmUY)_