### PR TITLE
feat(mobile): spectator live-view screen for in-progress games

### DIFF
--- a/.maestro/live-spectator.yaml
+++ b/.maestro/live-spectator.yaml
@@ -1,0 +1,36 @@
+appId: com.bballtracker.mobile
+---
+# Live Spectator: Create game → Start → Open live view → Verify screen renders + connects
+- launchApp:
+    clearState: true
+- tapOn: "Skip"
+- tapOn: "Developer login with test users"
+- assertVisible: "Select Test User"
+- tapOn: "Frank Vogel.*"
+- assertVisible: "Your Teams"
+
+# Create a game with the Lakers
+- tapOn: "Track game tab"
+- tapOn: "Create new game"
+- inputText:
+    id: "opponent-name-input"
+    text: "Spectator Rival"
+- tapOn: "Lakers.*"
+- tapOn: "Create Game"
+
+# Start the game so we have an IN_PROGRESS one to spectate
+- assertVisible: "Spectator Rival"
+- tapOn: "Start Game"
+
+# We start on the tracking screen — back out to the detail to find Watch Live.
+- assertVisible: "End game"
+- tapOn: "Go back"
+- tapOn: "Leave"
+
+- assertVisible: "Continue Tracking"
+- tapOn: "Watch Live"
+
+# Spectator screen renders: LIVE badge + opponent + initial score
+- assertVisible: "LIVE"
+- assertVisible: "Spectator Rival"
+- assertVisible: "0"

--- a/mobile/__tests__/hooks/useLiveGame.test.ts
+++ b/mobile/__tests__/hooks/useLiveGame.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for the useLiveGame hook.
+ */
+
+import { renderHook, act } from '@testing-library/react-native';
+
+interface AckFn {
+  (response: { success: boolean; gameId?: string; error?: string; code?: string }): void;
+}
+
+interface FakeSocket {
+  connected: boolean;
+  handlers: Record<string, ((...args: unknown[]) => void)[]>;
+  emitCalls: Array<{ event: string; payload: unknown; ack?: AckFn }>;
+  on: jest.Mock;
+  off: jest.Mock;
+  emit: jest.Mock;
+  connect: jest.Mock;
+  fire: (event: string, ...args: unknown[]) => void;
+}
+
+const createFakeSocket = (): FakeSocket => {
+  const socket: FakeSocket = {
+    connected: true,
+    handlers: {},
+    emitCalls: [],
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
+    connect: jest.fn(),
+    fire: (event, ...args) => {
+      (socket.handlers[event] ?? []).forEach((h) => h(...args));
+    },
+  };
+
+  socket.on.mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+    socket.handlers[event] = [...(socket.handlers[event] ?? []), handler];
+    return socket;
+  });
+  socket.off.mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+    socket.handlers[event] = (socket.handlers[event] ?? []).filter((h) => h !== handler);
+    return socket;
+  });
+  socket.emit.mockImplementation((event: string, payload: unknown, ack?: AckFn) => {
+    socket.emitCalls.push({ event, payload, ack });
+    if (event === 'join-game' && ack) ack({ success: true, gameId: 'g1' });
+    return socket;
+  });
+
+  return socket;
+};
+
+let mockSocket: FakeSocket;
+
+jest.mock('../../services/socket', () => ({
+  getSocket: jest.fn(() => mockSocket),
+}));
+
+import { useLiveGame } from '../../hooks/useLiveGame';
+
+const makeEvent = (id: string, gameId = 'g1') => ({
+  id,
+  gameId,
+  eventType: 'SHOT' as const,
+  timestamp: '2026-05-16T10:00:00Z',
+  metadata: { made: true, points: 2 } as const,
+  createdAt: '2026-05-16T10:00:00Z',
+});
+
+describe('useLiveGame', () => {
+  beforeEach(() => {
+    mockSocket = createFakeSocket();
+  });
+
+  it('emits join-game with the gameId on mount', () => {
+    renderHook(() => useLiveGame('g1'));
+    const join = mockSocket.emitCalls.find((c) => c.event === 'join-game');
+    expect(join).toBeDefined();
+    expect(join?.payload).toEqual({ gameId: 'g1' });
+  });
+
+  it('applies snapshot: score, status, events reversed to newest-first', () => {
+    const { result } = renderHook(() => useLiveGame('g1'));
+
+    act(() => {
+      mockSocket.fire('game-snapshot', {
+        game: {
+          id: 'g1',
+          teamId: 't1',
+          opponent: 'Rivals',
+          date: '2026-05-16T10:00:00Z',
+          status: 'IN_PROGRESS',
+          homeScore: 4,
+          awayScore: 2,
+        },
+        // Server sends chronologically (oldest first); hook should reverse.
+        events: [makeEvent('e1'), makeEvent('e2'), makeEvent('e3')],
+      });
+    });
+
+    expect(result.current.score).toEqual({ homeScore: 4, awayScore: 2 });
+    expect(result.current.status).toBe('IN_PROGRESS');
+    expect(result.current.connectionState).toBe('live');
+    expect(result.current.events.map((e) => e.id)).toEqual(['e3', 'e2', 'e1']);
+  });
+
+  it('appends game-event newest-first and updates score', () => {
+    const { result } = renderHook(() => useLiveGame('g1'));
+
+    act(() => {
+      mockSocket.fire('game-snapshot', {
+        game: {
+          id: 'g1',
+          teamId: 't1',
+          opponent: 'Rivals',
+          date: '2026-05-16T10:00:00Z',
+          status: 'IN_PROGRESS',
+          homeScore: 0,
+          awayScore: 0,
+        },
+        events: [makeEvent('e1')],
+      });
+    });
+
+    act(() => {
+      mockSocket.fire('game-event', {
+        event: makeEvent('e2'),
+        score: { homeScore: 2, awayScore: 0 },
+      });
+    });
+
+    expect(result.current.score).toEqual({ homeScore: 2, awayScore: 0 });
+    expect(result.current.events.map((e) => e.id)).toEqual(['e2', 'e1']);
+  });
+
+  it('dedupes events by id when the same id arrives twice', () => {
+    const { result } = renderHook(() => useLiveGame('g1'));
+
+    act(() => {
+      mockSocket.fire('game-snapshot', {
+        game: {
+          id: 'g1',
+          teamId: 't1',
+          opponent: 'Rivals',
+          date: '2026-05-16T10:00:00Z',
+          status: 'IN_PROGRESS',
+          homeScore: 0,
+          awayScore: 0,
+        },
+        events: [makeEvent('e1')],
+      });
+    });
+
+    act(() => {
+      mockSocket.fire('game-event', {
+        event: makeEvent('e1'),
+        score: { homeScore: 2, awayScore: 0 },
+      });
+    });
+
+    // Event list unchanged in length, but score still applied.
+    expect(result.current.events.map((e) => e.id)).toEqual(['e1']);
+    expect(result.current.score).toEqual({ homeScore: 2, awayScore: 0 });
+  });
+
+  it('applies game-status-change', () => {
+    const { result } = renderHook(() => useLiveGame('g1'));
+
+    act(() => {
+      mockSocket.fire('game-snapshot', {
+        game: {
+          id: 'g1',
+          teamId: 't1',
+          opponent: 'Rivals',
+          date: '2026-05-16T10:00:00Z',
+          status: 'IN_PROGRESS',
+          homeScore: 10,
+          awayScore: 8,
+        },
+        events: [],
+      });
+    });
+
+    act(() => {
+      mockSocket.fire('game-status-change', {
+        gameId: 'g1',
+        previousStatus: 'IN_PROGRESS',
+        status: 'FINISHED',
+        score: { homeScore: 10, awayScore: 8 },
+      });
+    });
+
+    expect(result.current.status).toBe('FINISHED');
+  });
+
+  it('re-emits join-game on reconnect', () => {
+    renderHook(() => useLiveGame('g1'));
+
+    const joinsBefore = mockSocket.emitCalls.filter((c) => c.event === 'join-game').length;
+    expect(joinsBefore).toBe(1);
+
+    act(() => {
+      mockSocket.fire('disconnect', 'transport close');
+      mockSocket.fire('connect');
+    });
+
+    const joinsAfter = mockSocket.emitCalls.filter((c) => c.event === 'join-game').length;
+    expect(joinsAfter).toBe(2);
+  });
+
+  it('emits leave-game on unmount and detaches listeners', () => {
+    const { unmount } = renderHook(() => useLiveGame('g1'));
+
+    unmount();
+
+    const leave = mockSocket.emitCalls.find((c) => c.event === 'leave-game');
+    expect(leave).toBeDefined();
+    expect(leave?.payload).toEqual({ gameId: 'g1' });
+
+    // Every on() should have been paired with an off().
+    expect(mockSocket.off).toHaveBeenCalledTimes(mockSocket.on.mock.calls.length);
+  });
+
+  it('does nothing when gameId is undefined', () => {
+    renderHook(() => useLiveGame(undefined));
+    expect(mockSocket.emit).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/__tests__/services/socket.test.ts
+++ b/mobile/__tests__/services/socket.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the socket.io-client singleton wrapper.
+ */
+
+import { io } from 'socket.io-client';
+
+jest.mock('socket.io-client', () => ({
+  io: jest.fn(),
+}));
+
+jest.mock('expo-constants', () => ({
+  __esModule: true,
+  default: { expoConfig: { extra: { apiUrl: 'http://test.local' } } },
+}));
+
+jest.mock('../../store/auth-store', () => ({
+  useAuthStore: {
+    getState: jest.fn(() => ({ accessToken: 'tok_abc' })),
+  },
+}));
+
+import { getSocket, resetSocket } from '../../services/socket';
+
+const mockedIo = io as jest.Mock;
+
+describe('socket wrapper', () => {
+  beforeEach(() => {
+    resetSocket();
+    mockedIo.mockReset();
+  });
+
+  it('lazily constructs a single socket', () => {
+    const fake = { removeAllListeners: jest.fn(), disconnect: jest.fn() };
+    mockedIo.mockReturnValue(fake);
+
+    const a = getSocket();
+    const b = getSocket();
+
+    expect(a).toBe(b);
+    expect(mockedIo).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the configured base URL and websocket-only transport', () => {
+    const fake = { removeAllListeners: jest.fn(), disconnect: jest.fn() };
+    mockedIo.mockReturnValue(fake);
+
+    getSocket();
+
+    const [url, opts] = mockedIo.mock.calls[0];
+    expect(url).toBe('http://test.local');
+    expect(opts.transports).toEqual(['websocket']);
+    expect(opts.reconnection).toBe(true);
+  });
+
+  it('supplies the current token via the auth callback on each call', () => {
+    const fake = { removeAllListeners: jest.fn(), disconnect: jest.fn() };
+    mockedIo.mockReturnValue(fake);
+
+    getSocket();
+
+    const opts = mockedIo.mock.calls[0][1];
+    const cb = jest.fn();
+    opts.auth(cb);
+    expect(cb).toHaveBeenCalledWith({ token: 'tok_abc' });
+  });
+
+  it('resetSocket disconnects and allows a fresh build', () => {
+    const fake = { removeAllListeners: jest.fn(), disconnect: jest.fn() };
+    mockedIo.mockReturnValue(fake);
+
+    getSocket();
+    resetSocket();
+
+    expect(fake.removeAllListeners).toHaveBeenCalled();
+    expect(fake.disconnect).toHaveBeenCalled();
+
+    const fresh = { removeAllListeners: jest.fn(), disconnect: jest.fn() };
+    mockedIo.mockReturnValue(fresh);
+    getSocket();
+    expect(mockedIo).toHaveBeenCalledTimes(2);
+  });
+});

--- a/mobile/app/games/[id]/index.tsx
+++ b/mobile/app/games/[id]/index.tsx
@@ -390,10 +390,18 @@ export default function GameDetailScreen() {
           {isInProgress && (
             <>
               <Button
+                title="Watch Live"
+                variant="secondary"
+                onPress={() => router.push(`/games/${id}/live`)}
+                fullWidth
+                size="large"
+              />
+              <Button
                 title="Continue Tracking"
                 onPress={handleContinueTracking}
                 fullWidth
                 size="large"
+                style={styles.endButton}
               />
               <Button
                 title="End Game"

--- a/mobile/app/games/[id]/live.tsx
+++ b/mobile/app/games/[id]/live.tsx
@@ -1,0 +1,285 @@
+/**
+ * Spectator live-view screen. Read-only.
+ *
+ * Renders score + recent plays driven by Socket.io. The initial useGame() call
+ * provides team name + a baseline render before the snapshot arrives so we
+ * don't flash a 0–0 placeholder against an unknown opponent.
+ */
+
+import React from 'react';
+import {
+  View,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+} from 'react-native';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  ThemedView,
+  ThemedText,
+  Card,
+  LoadingSpinner,
+  ErrorState,
+} from '../../../components';
+import { EventTimeline } from '../../../components/game';
+import { useGame } from '../../../hooks/useGames';
+import { useLiveGame } from '../../../hooks/useLiveGame';
+import { useTheme } from '../../../hooks/useTheme';
+import { spacing, typography } from '../../../theme';
+import { getHorizontalPadding } from '../../../utils/responsive';
+import type { GameStatus } from '../../../types/game';
+
+export default function GameLiveScreen() {
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { colors, colorScheme } = useTheme();
+  const padding = getHorizontalPadding();
+  const insets = useSafeAreaInsets();
+
+  const { data: game, isLoading, error, refetch } = useGame(id);
+  const live = useLiveGame(id);
+
+  const gradientColors =
+    colorScheme === 'dark'
+      ? (['#0D1117', '#161B22'] as const)
+      : (['#1A3A5C', '#0F2540'] as const);
+
+  if (isLoading) {
+    return <LoadingSpinner message="Loading game..." fullScreen />;
+  }
+
+  if (error || !game) {
+    return (
+      <ErrorState
+        message={error instanceof Error ? error.message : 'Game not found'}
+        onRetry={refetch}
+      />
+    );
+  }
+
+  // Prefer live snapshot once available, fall back to REST game.
+  const status: GameStatus = live.status ?? game.status;
+  const homeScore =
+    live.status !== null ? live.score.homeScore : game.homeScore;
+  const awayScore =
+    live.status !== null ? live.score.awayScore : game.awayScore;
+  const isLive = status === 'IN_PROGRESS';
+  const isFinished = status === 'FINISHED';
+  const isScheduled = status === 'SCHEDULED';
+
+  const showBanner =
+    live.connectionState === 'connecting' ||
+    live.connectionState === 'reconnecting' ||
+    live.connectionState === 'error';
+  const bannerText =
+    live.connectionState === 'error'
+      ? live.error ?? 'Connection error'
+      : live.connectionState === 'reconnecting'
+        ? 'Reconnecting…'
+        : 'Connecting…';
+
+  return (
+    <ThemedView variant="background" style={styles.container}>
+      <LinearGradient
+        colors={gradientColors}
+        style={[
+          styles.immersiveHeader,
+          { paddingTop: insets.top + spacing.sm },
+        ]}
+      >
+        <View style={[styles.headerActions, { paddingHorizontal: padding }]}>
+          <TouchableOpacity
+            onPress={() => router.back()}
+            style={styles.backButton}
+            accessibilityRole="button"
+            accessibilityLabel="Go back"
+          >
+            <Ionicons name="arrow-back" size={24} color="#FFFFFF" />
+          </TouchableOpacity>
+          <View style={styles.headerSpacer} />
+        </View>
+
+        <View style={styles.statusContainer}>
+          <View
+            style={[
+              styles.statusBadge,
+              {
+                backgroundColor:
+                  (isFinished ? colors.textTertiary : colors.error) + '30',
+              },
+            ]}
+            accessibilityLabel={isFinished ? 'Final' : isLive ? 'Live' : 'Status'}
+          >
+            {isLive && (
+              <View style={[styles.liveDot, { backgroundColor: colors.error }]} />
+            )}
+            <ThemedText
+              variant="captionBold"
+              style={{
+                color: isFinished ? colors.textTertiary : colors.error,
+              }}
+            >
+              {isFinished ? 'FINAL' : isLive ? 'LIVE' : 'Not Started'}
+            </ThemedText>
+          </View>
+        </View>
+
+        <View style={styles.scoreContainer}>
+          <View style={styles.teamScore}>
+            <ThemedText variant="caption" style={styles.headerTeamName}>
+              {game.team?.name || 'Your Team'}
+            </ThemedText>
+            <ThemedText variant="body" style={styles.headerScore}>
+              {homeScore}
+            </ThemedText>
+          </View>
+          <View style={styles.scoreDivider}>
+            <View style={styles.verticalLine} />
+          </View>
+          <View style={[styles.teamScore, styles.awayTeamScore]}>
+            <ThemedText variant="caption" style={styles.headerTeamName}>
+              {game.opponent}
+            </ThemedText>
+            <ThemedText variant="body" style={styles.headerScore}>
+              {awayScore}
+            </ThemedText>
+          </View>
+        </View>
+      </LinearGradient>
+
+      {showBanner && (
+        <View
+          style={[styles.banner, { backgroundColor: colors.backgroundSecondary }]}
+          accessibilityLabel="Connection status"
+        >
+          <Ionicons
+            name="sync"
+            size={14}
+            color={colors.textSecondary}
+          />
+          <ThemedText variant="caption" color="textSecondary">
+            {bannerText}
+          </ThemedText>
+        </View>
+      )}
+
+      <ScrollView
+        contentContainerStyle={[
+          styles.scrollContent,
+          { padding, paddingBottom: insets.bottom + spacing.xl },
+        ]}
+        showsVerticalScrollIndicator={false}
+      >
+        {isScheduled ? (
+          <Card variant="default" style={styles.emptyCard}>
+            <Ionicons
+              name="time-outline"
+              size={32}
+              color={colors.textTertiary}
+            />
+            <ThemedText variant="body" color="textSecondary" style={styles.emptyText}>
+              Game hasn&apos;t started yet
+            </ThemedText>
+          </Card>
+        ) : (
+          <EventTimeline events={live.events} maxEvents={20} />
+        )}
+      </ScrollView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  immersiveHeader: {
+    paddingBottom: spacing.lg,
+    borderBottomLeftRadius: 20,
+    borderBottomRightRadius: 20,
+  },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  backButton: {
+    padding: spacing.sm,
+    marginLeft: -spacing.xs,
+  },
+  headerSpacer: {
+    flex: 1,
+  },
+  statusContainer: {
+    alignItems: 'center',
+    marginBottom: spacing.md,
+  },
+  statusBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: 16,
+    gap: spacing.xs,
+  },
+  liveDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  scoreContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing.sm,
+  },
+  teamScore: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  awayTeamScore: {
+    alignItems: 'center',
+  },
+  headerTeamName: {
+    color: '#FFFFFF',
+    textTransform: 'uppercase',
+    letterSpacing: 2,
+    marginBottom: spacing.xs,
+  },
+  headerScore: {
+    ...typography.displaySmall,
+    color: '#FFFFFF',
+    lineHeight: 64,
+  },
+  scoreDivider: {
+    paddingHorizontal: spacing.xl,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  verticalLine: {
+    width: 1,
+    height: 40,
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+  },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingVertical: spacing.xs,
+  },
+  scrollContent: {
+    paddingTop: spacing.lg,
+  },
+  emptyCard: {
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.xl,
+  },
+  emptyText: {
+    textAlign: 'center',
+  },
+});

--- a/mobile/hooks/useLiveGame.ts
+++ b/mobile/hooks/useLiveGame.ts
@@ -1,0 +1,212 @@
+/**
+ * Subscribe to a game room over Socket.io and expose live state.
+ *
+ * Lifecycle: on mount → join the room → install listeners → wait for snapshot.
+ * On reconnect → re-join (server returns a fresh snapshot). On unmount →
+ * remove listeners and leave the room (we keep the underlying socket open;
+ * it's a singleton).
+ *
+ * Backend protocol contract — see backend/src/websocket/game-events.ts:
+ *  - emit `join-game` with `{ gameId }` (ack: { success, gameId | error, code })
+ *  - receive `game-snapshot`: { game, events } (events oldest-first)
+ *  - receive `game-event`: { event, score }
+ *  - receive `game-status-change`: { gameId, previousStatus, status, score }
+ */
+
+import { useEffect, useReducer, useRef } from 'react';
+import type { Socket } from 'socket.io-client';
+import { getSocket } from '../services/socket';
+import type { GameEvent, GameStatus } from '../types/game';
+
+export type ConnectionState = 'connecting' | 'live' | 'reconnecting' | 'error';
+
+interface Score {
+  homeScore: number;
+  awayScore: number;
+}
+
+interface SnapshotGame {
+  id: string;
+  teamId: string;
+  opponent: string;
+  date: string;
+  status: GameStatus;
+  homeScore: number;
+  awayScore: number;
+}
+
+interface GameSnapshotPayload {
+  game: SnapshotGame;
+  events: GameEvent[];
+}
+
+interface GameEventBroadcast {
+  event: GameEvent;
+  score: Score;
+}
+
+interface GameStatusChangeBroadcast {
+  gameId: string;
+  previousStatus: GameStatus;
+  status: GameStatus;
+  score: Score;
+}
+
+interface JoinAck {
+  success: boolean;
+  gameId?: string;
+  error?: string;
+  code?: string;
+}
+
+const EVENT_CAP = 20;
+
+interface State {
+  score: Score;
+  status: GameStatus | null;
+  events: GameEvent[]; // newest first, capped at EVENT_CAP
+  connectionState: ConnectionState;
+  error: string | null;
+}
+
+type Action =
+  | { type: 'connecting' }
+  | { type: 'reconnecting' }
+  | { type: 'snapshot'; payload: GameSnapshotPayload }
+  | { type: 'event'; payload: GameEventBroadcast }
+  | { type: 'statusChange'; payload: GameStatusChangeBroadcast }
+  | { type: 'error'; message: string };
+
+const initialState: State = {
+  score: { homeScore: 0, awayScore: 0 },
+  status: null,
+  events: [],
+  connectionState: 'connecting',
+  error: null,
+};
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'connecting':
+      return { ...state, connectionState: 'connecting', error: null };
+    case 'reconnecting':
+      return { ...state, connectionState: 'reconnecting', error: null };
+    case 'snapshot': {
+      // Server returns events oldest-first; we render newest-first.
+      const newest = [...action.payload.events].reverse().slice(0, EVENT_CAP);
+      return {
+        score: {
+          homeScore: action.payload.game.homeScore,
+          awayScore: action.payload.game.awayScore,
+        },
+        status: action.payload.game.status,
+        events: newest,
+        connectionState: 'live',
+        error: null,
+      };
+    }
+    case 'event': {
+      const incoming = action.payload.event;
+      // Dedupe — snapshot+stream race can deliver the same event twice.
+      if (state.events.some((e) => e.id === incoming.id)) {
+        return { ...state, score: action.payload.score };
+      }
+      const events = [incoming, ...state.events].slice(0, EVENT_CAP);
+      return { ...state, score: action.payload.score, events };
+    }
+    case 'statusChange':
+      return {
+        ...state,
+        status: action.payload.status,
+        score: action.payload.score,
+      };
+    case 'error':
+      return { ...state, connectionState: 'error', error: action.message };
+    default:
+      return state;
+  }
+}
+
+export interface UseLiveGameResult {
+  score: Score;
+  status: GameStatus | null;
+  events: GameEvent[];
+  connectionState: ConnectionState;
+  error: string | null;
+}
+
+export function useLiveGame(gameId: string | undefined): UseLiveGameResult {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const socketRef = useRef<Socket | null>(null);
+
+  useEffect(() => {
+    if (!gameId) return;
+
+    const socket = getSocket();
+    socketRef.current = socket;
+
+    const join = () => {
+      socket.emit('join-game', { gameId }, (ack: JoinAck) => {
+        if (!ack?.success) {
+          dispatch({
+            type: 'error',
+            message: ack?.error ?? 'Failed to join game',
+          });
+        }
+      });
+    };
+
+    const handleSnapshot = (payload: GameSnapshotPayload) => {
+      if (payload?.game?.id !== gameId) return;
+      dispatch({ type: 'snapshot', payload });
+    };
+
+    const handleEvent = (payload: GameEventBroadcast) => {
+      if (payload?.event?.gameId !== gameId) return;
+      dispatch({ type: 'event', payload });
+    };
+
+    const handleStatusChange = (payload: GameStatusChangeBroadcast) => {
+      if (payload?.gameId !== gameId) return;
+      dispatch({ type: 'statusChange', payload });
+    };
+
+    const handleConnect = () => {
+      dispatch({ type: 'connecting' });
+      join();
+    };
+
+    const handleDisconnect = () => {
+      dispatch({ type: 'reconnecting' });
+    };
+
+    const handleConnectError = (err: Error) => {
+      dispatch({ type: 'error', message: err.message });
+    };
+
+    socket.on('game-snapshot', handleSnapshot);
+    socket.on('game-event', handleEvent);
+    socket.on('game-status-change', handleStatusChange);
+    socket.on('connect', handleConnect);
+    socket.on('disconnect', handleDisconnect);
+    socket.on('connect_error', handleConnectError);
+
+    if (socket.connected) {
+      join();
+    } else {
+      socket.connect();
+    }
+
+    return () => {
+      socket.off('game-snapshot', handleSnapshot);
+      socket.off('game-event', handleEvent);
+      socket.off('game-status-change', handleStatusChange);
+      socket.off('connect', handleConnect);
+      socket.off('disconnect', handleDisconnect);
+      socket.off('connect_error', handleConnectError);
+      socket.emit('leave-game', { gameId });
+    };
+  }, [gameId]);
+
+  return state;
+}

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -48,6 +48,7 @@
         "react-native-screens": "~4.23.0",
         "react-native-svg": "15.15.3",
         "react-native-worklets": "^0.7.4",
+        "socket.io-client": "^4.8.3",
         "zod": "^4.4.3",
         "zustand": "^5.0.13"
       },
@@ -6985,6 +6986,12 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.100.10",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.10.tgz",
@@ -9310,6 +9317,49 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/entities": {
@@ -16853,6 +16903,34 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -18294,6 +18372,14 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -55,6 +55,7 @@
     "react-native-screens": "~4.23.0",
     "react-native-svg": "15.15.3",
     "react-native-worklets": "^0.7.4",
+    "socket.io-client": "^4.8.3",
     "zod": "^4.4.3",
     "zustand": "^5.0.13"
   },

--- a/mobile/services/socket.ts
+++ b/mobile/services/socket.ts
@@ -1,0 +1,46 @@
+/**
+ * Socket.io client singleton.
+ *
+ * One persistent connection per app launch. Lazily constructed on first
+ * `getSocket()` call. The auth token is supplied via a callback so reconnects
+ * pick up a rotated token without recreating the socket.
+ *
+ * RN note: pin transport to ['websocket']. The polling fallback works poorly
+ * on iOS/Android and adds latency.
+ */
+
+import Constants from 'expo-constants';
+import { io, type Socket } from 'socket.io-client';
+import { useAuthStore } from '../store/auth-store';
+
+const getBaseURL = (): string => {
+  return (
+    Constants.expoConfig?.extra?.apiUrl ||
+    (__DEV__ ? 'http://127.0.0.1:3000' : 'https://api.capyhoops.com')
+  );
+};
+
+let socket: Socket | null = null;
+
+export function getSocket(): Socket {
+  if (socket) return socket;
+
+  socket = io(getBaseURL(), {
+    transports: ['websocket'],
+    reconnection: true,
+    autoConnect: true,
+    auth: (cb) => {
+      const token = useAuthStore.getState().accessToken;
+      cb({ token: token ?? '' });
+    },
+  });
+
+  return socket;
+}
+
+export function resetSocket(): void {
+  if (!socket) return;
+  socket.removeAllListeners();
+  socket.disconnect();
+  socket = null;
+}


### PR DESCRIPTION
## Summary

Adds a read-only live-view spectator screen for games in progress. Parents/fans can tap **Watch Live** on the game detail screen of any `IN_PROGRESS` game to see the score and play-by-play feed update in real time over Socket.io.

Pairs with #26 (backend Socket.io handlers, shipped April). Refs #27 — leaving the issue open for the AC review at merge time per project convention.

## What changed

- **`mobile/services/socket.ts`** — Lazy Socket.io client singleton. Websocket-only transport (polling fallback is flaky in RN). Token supplied via auth callback so reconnects pick up a rotated token.
- **`mobile/hooks/useLiveGame.ts`** — Reducer-driven hook. Snapshot wholesale-replaces local state on (re)join; `game-event` appends newest-first capped at 20 and dedupes by `event.id`; `game-status-change` updates status + score. Re-emits `join-game` on `connect` so reconnects refresh state. Emits `leave-game` on unmount.
- **`mobile/app/games/[id]/live.tsx`** — Gradient header with LIVE / FINAL / "Not Started" badge, connection banner ("Reconnecting…"), and reuses `<EventTimeline>` for the feed. Keeps a `useGame()` call for the initial render so the opponent name shows before the snapshot arrives. Read-only — no stat entry.
- **`mobile/app/games/[id]/index.tsx`** — Secondary "Watch Live" button above "Continue Tracking" in the `IN_PROGRESS` branch.
- **Unit tests** — 12 new Jest cases covering the singleton wrapper and the hook's reducer (snapshot, event append, dedupe, status change, reconnect re-join, leave-game on unmount, no-op on undefined id).
- **Maestro flow** `.maestro/live-spectator.yaml` — dev-login → start a game → tap Watch Live → assert LIVE badge + opponent name + initial score render. Cross-stack live-update assertion deferred to synthetic prod tests (a smaller follow-up).

## AC status (issue #27)

- [x] Score + status + play-by-play feed
- [x] Real-time `game-event` updates (no polling)
- [x] Reconnect re-subscribes and pulls a fresh snapshot
- [x] "Reconnecting…" banner when not live
- [x] Handles FINISHED mid-session (badge flips to FINAL, listener stays attached)
- [x] Read-only — no stat entry
- [x] Reuses `useTheme()`, `LoadingSpinner`, `ErrorState`, `EventTimeline`
- [x] Maestro flow added — verifies navigation + initial render; live-update assertion deferred to synthetic prod tests

## Test plan

- [x] `cd mobile && npm run type-check` — clean
- [x] `cd mobile && npm test` — 393/393 passing (12 new)
- [x] `npx expo export --platform ios` — bundles cleanly (proves `socket.io-client` transitive deps resolve through Metro)
- [ ] `cd mobile && npm run lint` — **skipped**, eslint is uninstalled (existing issue #64; out of scope here)
- [ ] `maestro test .maestro/live-spectator.yaml` — will run on CI's `test-mobile` job
- [ ] Manual smoke after merge: two devices, one tracking + one spectating, watch score + feed update

## Deploy plan

`socket.io-client` is pure JS so no native modules are added, but per agreed cadence:

1. **First release** — cut a fresh preview build (`npx eas-cli build --platform ios --profile preview`) to validate the new dependency boots through Hermes on a real device.
2. **Preview soak** — install, smoke-test live updates with two devices.
3. **Production OTA** — once preview soaks ~1 day, `npx eas-cli update --environment production --message "Spectator live view"`.
4. **Rollback** if needed — `npx eas-cli update:roll-back-to-embedded --environment production`.

Subsequent iterations on this feature: OTA-first per the agreed cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)