### PR TITLE
chore(deps): bump backend patch deps (2026-05-21)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1050.0",
-        "@aws-sdk/s3-request-presigner": "^3.1050.0",
+        "@aws-sdk/client-s3": "^3.1051.0",
+        "@aws-sdk/s3-request-presigner": "^3.1051.0",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "@sentry/node": "^10.53.1",
@@ -47,7 +47,7 @@
         "jest": "^29.7.0",
         "socket.io-client": "^4.8.3",
         "supertest": "^7.1.3",
-        "ts-jest": "^29.4.10",
+        "ts-jest": "^29.4.11",
         "tsx": "^4.22.3",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.4"
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1050.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1050.0.tgz",
-      "integrity": "sha512-9kgtv+bXZQrOIJT2INPPBCezrJu1FlgGrzEat/ut4A4V53IT00LynsBZgp12eFKbjJuNCeTo7iPSKjPsX8ub+A==",
+      "version": "3.1051.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1051.0.tgz",
+      "integrity": "sha512-0Yhq7AMw2te5YtxDHkm2KKpXF8IccOO4nmCsp12EzYB/e3IKQ73NHH4jA2ki8mQwvAQzFGB+1GoycT00U8sZCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -469,9 +469,9 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1050.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1050.0.tgz",
-      "integrity": "sha512-tTQ+MYyQehtA5SMXnLumFpOMrVBcn88f1k6oyzs4sOQ1Upq72T/BYkKZ+Yn7ejncSsCp3exIVcYwZHFEGKAugQ==",
+      "version": "3.1051.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1051.0.tgz",
+      "integrity": "sha512-9ZULJHf5IAObmqtg2XhiufMmgEl+aM9jlRog2V9qbICeSOgDCHekmlRxF9FuqZKMqrpLzGtJPDbd8gGAHJZv/A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.12",
@@ -9316,9 +9316,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.10",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.10.tgz",
-      "integrity": "sha512-vMTlTTtvz5aKZgzOoc7DQ5TzAL2fCzl8JnG1+ZpwjQa/g0xLlwE44yQ+1Cao9ZP1xVv9y5g34IFXEiqGOGFBUA==",
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,8 +27,8 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1050.0",
-    "@aws-sdk/s3-request-presigner": "^3.1050.0",
+    "@aws-sdk/client-s3": "^3.1051.0",
+    "@aws-sdk/s3-request-presigner": "^3.1051.0",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@sentry/node": "^10.53.1",
@@ -74,7 +74,7 @@
     "jest": "^29.7.0",
     "socket.io-client": "^4.8.3",
     "supertest": "^7.1.3",
-    "ts-jest": "^29.4.10",
+    "ts-jest": "^29.4.11",
     "tsx": "^4.22.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4"


### PR DESCRIPTION
Automated daily upgrade scan — backend lockfile/caret patch bumps within existing semver ranges.

| Package | From | To |
| --- | --- | --- |
| `@aws-sdk/client-s3` | 3.1050.0 | 3.1051.0 |
| `@aws-sdk/s3-request-presigner` | 3.1050.0 | 3.1051.0 |
| `ts-jest` | 29.4.10 | 29.4.11 |

**CVE refs:** none in this batch.

**Quality gates:**
- `npm run type-check` — clean
- `npm test` — 790/790 passed (47 suites)

Diff guard: only `backend/package.json` + `backend/package-lock.json` changed.

Deferred this cycle (see #77): `jest`, `@types/jest`, `@workos-inc/node`.

🤖 Generated by the Daily Upgrade Scan routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW5N391KS1H4nRSyYwiWTC)_