### PR TITLE
chore(deps): bump backend patch deps (2026-05-23)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1052.0",
-        "@aws-sdk/s3-request-presigner": "^3.1052.0",
+        "@aws-sdk/client-s3": "^3.1053.0",
+        "@aws-sdk/s3-request-presigner": "^3.1053.0",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "@sentry/node": "^10.53.1",
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1052.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1052.0.tgz",
-      "integrity": "sha512-8fgQHfk1WjGUyowyqtMwq9HzZvIQQ86cqn9IZW5Qkq8kaolVjMmZez60qVYxKYvKhVRYUP5hWYPVCyraoud0AA==",
+      "version": "3.1053.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1053.0.tgz",
+      "integrity": "sha512-/oGxoB6p1Nqs935Blt+v1o+anSCEf2n3RjIrcLz84i4cn2Gr+Z7JpDdUkG5+74r5ctqEPG7k/phTGbJ9fNKnHg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -469,9 +469,9 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1052.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1052.0.tgz",
-      "integrity": "sha512-VDULO8AQlgcYZHRYn3qaBfYiM//aWxdlvQsTdcP+EQgSjki3z+mhD7rMy1RKnu4VvRK/xjJFOKwMA3cDM8eLtw==",
+      "version": "3.1053.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1053.0.tgz",
+      "integrity": "sha512-F2424BizKG4Jg/I7kr9bNCRqE1fo8ZnHBad+s3KalL20SwI1KCk7KnVJRdIpNVHbHqrhg/UZaLxaAjY7vLUUYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.13",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,8 +27,8 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1052.0",
-    "@aws-sdk/s3-request-presigner": "^3.1052.0",
+    "@aws-sdk/client-s3": "^3.1053.0",
+    "@aws-sdk/s3-request-presigner": "^3.1053.0",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@sentry/node": "^10.53.1",


### PR DESCRIPTION
Automated daily upgrade scan — lockfile-only patch bumps within the existing caret range.

| Package                         | From       | To         |
| ------------------------------- | ---------- | ---------- |
| @aws-sdk/client-s3              | 3.1052.0   | 3.1053.0   |
| @aws-sdk/s3-request-presigner   | 3.1052.0   | 3.1053.0   |

## Quality gates
- `npm run type-check`: pass
- `npm test`: 790 passed across 47 suites

## Diff guard
Only `backend/package.json` and `backend/package-lock.json` modified.

Auto-merge enabled; see `docs/automation/daily-upgrade-scan.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBppGX2TAMkVJ5dUnso2qE)_