### PR TITLE
chore(deps): bump mobile patch deps (2026-05-23)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -16,7 +16,7 @@
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/datetimepicker": "^8.6.0",
         "@sentry/react-native": "^8.12.0",
-        "@tanstack/react-query": "^5.100.11",
+        "@tanstack/react-query": "^5.100.13",
         "axios": "^1.16.1",
         "babel-preset-expo": "^55.0.22",
         "expo": "^55.0.26",
@@ -7006,9 +7006,9 @@
       "license": "MIT"
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.100.11",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.11.tgz",
-      "integrity": "sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==",
+      "version": "5.100.13",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.13.tgz",
+      "integrity": "sha512-mlKVKMTzZWGTKAC1CKOgt7axAjJ921emkEvYIp27I/PdP1yEYL/BteLY8iK35gn8hoYeKB4mgJ/ve3lrDI6/Fw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7016,12 +7016,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.100.11",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.11.tgz",
-      "integrity": "sha512-J0f9s5x3LE1450nNNfYx+e/n0DMa0uOBdFJUy5r0RvmsXd4nB/n0rbHtHI1vYXhikNFan+wf51p6Tmp4c8ucrg==",
+      "version": "5.100.13",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.13.tgz",
+      "integrity": "sha512-HSBr8CycQEAoXsJR7KNDawBnINJEJ96Eme8oE0hCXjyodE2I97vg3IDzDJBDu18LsbzpVVJcKo80eqLfVCykxw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.100.11"
+        "@tanstack/query-core": "5.100.13"
       },
       "funding": {
         "type": "github",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -23,7 +23,7 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "^8.6.0",
     "@sentry/react-native": "^8.12.0",
-    "@tanstack/react-query": "^5.100.11",
+    "@tanstack/react-query": "^5.100.13",
     "axios": "^1.16.1",
     "babel-preset-expo": "^55.0.22",
     "expo": "^55.0.26",


### PR DESCRIPTION
Automated daily upgrade scan — lockfile-only patch bumps within the existing caret range.

| Package                | From       | To         |
| ---------------------- | ---------- | ---------- |
| @tanstack/react-query  | 5.100.11   | 5.100.13   |

## Quality gates
- `npm run type-check`: pass
- `npm test`: 393 passed across 38 suites
- `npx expo export --platform ios`: success

## Diff guard
Only `mobile/package.json` and `mobile/package-lock.json` modified.

Auto-merge enabled; see `docs/automation/daily-upgrade-scan.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBppGX2TAMkVJ5dUnso2qE)_