### PR TITLE
chore(deps): bump mobile patch deps (2026-05-24)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -16,7 +16,7 @@
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/datetimepicker": "^8.6.0",
         "@sentry/react-native": "^8.12.0",
-        "@tanstack/react-query": "^5.100.13",
+        "@tanstack/react-query": "^5.100.14",
         "axios": "^1.16.1",
         "babel-preset-expo": "^55.0.22",
         "expo": "^55.0.26",
@@ -7006,9 +7006,9 @@
       "license": "MIT"
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.100.13",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.13.tgz",
-      "integrity": "sha512-mlKVKMTzZWGTKAC1CKOgt7axAjJ921emkEvYIp27I/PdP1yEYL/BteLY8iK35gn8hoYeKB4mgJ/ve3lrDI6/Fw==",
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.14.tgz",
+      "integrity": "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7016,12 +7016,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.100.13",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.13.tgz",
-      "integrity": "sha512-HSBr8CycQEAoXsJR7KNDawBnINJEJ96Eme8oE0hCXjyodE2I97vg3IDzDJBDu18LsbzpVVJcKo80eqLfVCykxw==",
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.14.tgz",
+      "integrity": "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.100.13"
+        "@tanstack/query-core": "5.100.14"
       },
       "funding": {
         "type": "github",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -23,7 +23,7 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "^8.6.0",
     "@sentry/react-native": "^8.12.0",
-    "@tanstack/react-query": "^5.100.13",
+    "@tanstack/react-query": "^5.100.14",
     "axios": "^1.16.1",
     "babel-preset-expo": "^55.0.22",
     "expo": "^55.0.26",


### PR DESCRIPTION
Auto-fix batch from the Daily Upgrade Scan routine (2026-05-24).

| Package | From | To |
| --- | --- | --- |
| `@tanstack/react-query` | 5.100.13 | 5.100.14 |

Lockfile-only patch bump (within existing caret range — no `package.json` range change beyond bumping the caret floor).

### Quality gates

- `npm run type-check` — clean
- `npm test` — 393/393 pass
- `npx expo export --platform ios` — success

### Diff guard

Only `mobile/package.json` and `mobile/package-lock.json` changed.

### CVE refs

None — no security advisories tied to this bump.

---
_Generated by the Daily Upgrade Scan routine. See [`docs/automation/daily-upgrade-scan.md`](https://github.com/deasystephen/bball-tracker/blob/main/docs/automation/daily-upgrade-scan.md)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JG1ezLvKXtoxw8VtpRUcth)_