### PR TITLE
chore(mobile): declare ITSAppUsesNonExemptEncryption=false

### DIFF
--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -36,6 +36,9 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: 'com.bballtracker.mobile',
+      config: {
+        usesNonExemptEncryption: false,
+      },
     },
     android: {
       adaptiveIcon: {


### PR DESCRIPTION
## Summary
- Adds `ios.config.usesNonExemptEncryption: false` to `mobile/app.config.js`
- Removes the manual Export Compliance prompt step in App Store Connect for future TestFlight builds

## Why
EAS build #16 surfaced this warning:

> app.config.js is missing ios.infoPlist.ITSAppUsesNonExemptEncryption boolean. Manual configuration is required in App Store Connect before the app can be tested.

The app uses only HTTPS / Apple-provided crypto APIs — no custom encryption — so `false` is the correct declaration. Setting it in `app.config.js` makes Expo write `ITSAppUsesNonExemptEncryption=NO` into Info.plist on every build, so the manual ASC step disappears for build #17+.

Build #16 still needs the one-time ASC click; this PR is purely forward-looking.

## Test plan
- [ ] CI green (type-check + tests)
- [ ] Next production EAS build (#17+) does not emit the missing-encryption warning
- [ ] Next TestFlight build can be sent to testers without manually answering the Export Compliance prompt in ASC

🤖 Generated with [Claude Code](https://claude.com/claude-code)