### PR TITLE
docs(automation): record Phase-2 unblock prereqs (branch protection, Watch settings)

### DIFF
--- a/docs/automation/daily-upgrade-scan.md
+++ b/docs/automation/daily-upgrade-scan.md
@@ -25,11 +25,12 @@ The routine batches all eligible items per side (backend, mobile) into one PR pe
 
 ## Prerequisites
 
-These are one-time setup items. All are already in place as of this routine going live:
+These are one-time setup items. All are already in place as of 2026-05-03:
 
 1. ✅ Repo settings: `allow_auto_merge: true`, `delete_branch_on_merge: true`
-2. ✅ Repo Watch with at least "Issues" notifications enabled (for the daily-log email)
-3. ✅ Claude GitHub App installed on `deasystephen/bball-tracker` with write access to contents, issues, and pull requests
+2. ✅ Branch protection on `main` requiring CI status checks (`Lint and Type Check (backend)`, `Lint and Type Check (mobile)`, `Test Backend`, `Test Mobile`, `Analyze (javascript-typescript)`). **Required** for `gh pr merge --auto` to work — without it, GitHub returns `Protected branch rules not configured for this branch` and auto-merge silently fails. Verify with `gh api repos/deasystephen/bball-tracker/branches/main/protection`.
+3. ✅ Repo Watch with at least "Issues" notifications enabled, AND user-level **"Include your own updates"** enabled at github.com/settings/notifications. The latter is required because the routine commits/comments under the repo owner's identity, and GitHub by default suppresses email notifications for activity attributed to you.
+4. ✅ Claude GitHub App installed on `deasystephen/bball-tracker` with write access to contents, issues, and pull requests
 
 ## Routine prompt
 


### PR DESCRIPTION
## Summary
- Documents two prerequisites that turned out to be load-bearing for the Daily Upgrade Scan routine working end-to-end
- Branch protection on `main` is required for `gh pr merge --auto` to function
- User-level "Include your own updates" notification setting is required for daily-log emails to reach the repo owner

## Why
Both of these were discovered during routine bring-up after Phase 2 was already live. The prereqs section previously implied initial setup was complete; this PR records the additional items that emerged. State is already captured in agent memory — this puts it where the next operator looks first.

## Test plan
- [ ] No code changes; markdown rendering check on the PR diff view

🤖 Generated with [Claude Code](https://claude.com/claude-code)