### PR TITLE
fix(infra): ignore task_definition changes on ECS service (#53)

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -341,9 +341,13 @@ resource "aws_ecs_service" "app" {
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 50
 
-  # Ignore changes to desired_count since auto-scaling manages it
+  # desired_count is managed by ECS auto-scaling.
+  # task_definition is managed by the CI/CD deploy job (Build & Deploy to ECS),
+  # which registers a new revision and updates the service out-of-band from Terraform.
+  # Without ignoring it here, `terraform plan` reads the stale revision from state
+  # and would roll the service back to that revision on apply. See #53.
   lifecycle {
-    ignore_changes = [desired_count]
+    ignore_changes = [desired_count, task_definition]
   }
 
   depends_on = [aws_lb_listener.http]


### PR DESCRIPTION
## Summary
- Adds `task_definition` to the `ignore_changes` list on `aws_ecs_service.app` in `infra/ecs.tf`
- One-line lifecycle change, no functional impact on running infra

## Why
While planning a separate SES infra apply, `terraform plan` showed an unexpected change: `aws_ecs_service.app` would be updated in-place to roll `task_definition` from `arn:...api:121` → `arn:...api:24`. That's ~97 revisions of CI/CD-driven config rolled back — would have wiped months of deploys if applied blindly.

Root cause is the split-brain documented in #53: the CI/CD "Build & Deploy to ECS" job registers new task-definition revisions and updates the service out-of-band from Terraform. Terraform state still records the revision it set during the initial bring-up, so any future `terraform apply` reads that stale value and tries to revert.

`ignore_changes = [task_definition]` is the minimum-risk fix: Terraform stops fighting the deploy job, the service continues to be managed by CI/CD for task-def updates. No state mutation needed.

## Resolves the split-brain side of #53
The longer-term decision (Terraform owns task-defs vs. CI/CD owns task-defs) can stay open in #53 — this is just the unblocker.

## Test plan
- [ ] CI passes (terraform fmt + validate — verified locally)
- [ ] After merge: `cd infra && terraform plan` shows the 8 SES additions only, no ECS change
- [ ] No production traffic impact (lifecycle attribute only affects future plans)

🤖 Generated with [Claude Code](https://claude.com/claude-code)