### PR TITLE
feat(mailer): wire invite accept URL into invitation email template

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -37,6 +37,10 @@ AWS_SECRET_ACCESS_KEY=""
 AWS_SES_REGION="us-east-1"
 SES_FROM_ADDRESS="noreply@mail.capyhoops.com"
 
+# Public web app base URL (used for invite accept links in emails, calendar UIDs).
+# Defaults to https://capyhoops.com if unset.
+PUBLIC_APP_URL="https://capyhoops.com"
+
 # CORS
 CORS_ORIGIN="http://localhost:19006"
 

--- a/backend/src/services/invitation-service.ts
+++ b/backend/src/services/invitation-service.ts
@@ -147,6 +147,8 @@ export class InvitationService {
 
     // Send invitation email (fire-and-forget; never block the response)
     if (invitation.player.email) {
+      const baseUrl = process.env.PUBLIC_APP_URL || 'https://capyhoops.com';
+      const acceptUrl = `${baseUrl}/invite/${invitation.token}`;
       mailer
         .send({
           template: invitationTemplate,
@@ -157,6 +159,7 @@ export class InvitationService {
             inviterName: invitation.invitedBy.name ?? invitation.invitedBy.email ?? '',
             message: invitation.message ?? '',
             expiresAt: invitation.expiresAt.toLocaleDateString(),
+            acceptUrl,
           },
           metadata: {
             userId: invitation.playerId,

--- a/backend/src/services/mailer/templates/invitation.ts
+++ b/backend/src/services/mailer/templates/invitation.ts
@@ -10,6 +10,12 @@ export const invitationTemplate: EmailTemplate = {
     const messageBlock = vars.message
       ? `<p style="color:#555;font-style:italic;">"${e(vars.message)}"</p>`
       : '';
+    const ctaBlock = vars.acceptUrl
+      ? `<p style="margin:24px 0;">
+    <a href="${e(vars.acceptUrl)}" style="display:inline-block;background:#1A3A5C;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:600;">Accept Invitation</a>
+  </p>
+  <p style="color:#999;font-size:12px;">Or open this link: <a href="${e(vars.acceptUrl)}">${e(vars.acceptUrl)}</a></p>`
+      : '<p>Open the CapyHoops app to accept or decline your invitation.</p>';
     return `<!DOCTYPE html>
 <html>
 <head><meta charset="UTF-8"></head>
@@ -19,7 +25,7 @@ export const invitationTemplate: EmailTemplate = {
   <p>${e(vars.inviterName)} has invited you to join <strong>${e(vars.teamName)}</strong>.</p>
   ${messageBlock}
   <p>This invitation expires on ${e(vars.expiresAt)}.</p>
-  <p>Open the CapyHoops app to accept or decline your invitation.</p>
+  ${ctaBlock}
   <hr>
   <p style="color:#999;font-size:12px;">CapyHoops — Basketball Tracker</p>
 </body>
@@ -27,6 +33,9 @@ export const invitationTemplate: EmailTemplate = {
   },
   text(vars) {
     const messageBlock = vars.message ? `\n"${vars.message}"\n` : '';
+    const ctaBlock = vars.acceptUrl
+      ? `Accept your invitation: ${vars.acceptUrl}`
+      : 'Open the CapyHoops app to accept or decline your invitation.';
     return `You've been invited to join ${vars.teamName}!
 
 Hi ${vars.playerName},
@@ -35,7 +44,7 @@ ${vars.inviterName} has invited you to join ${vars.teamName}.
 ${messageBlock}
 This invitation expires on ${vars.expiresAt}.
 
-Open the CapyHoops app to accept or decline your invitation.
+${ctaBlock}
 
 CapyHoops — Basketball Tracker`;
   },

--- a/backend/tests/services/invitation-service.test.ts
+++ b/backend/tests/services/invitation-service.test.ts
@@ -92,6 +92,58 @@ describe('InvitationService', () => {
       expect(result).toHaveProperty('playerId', player.id);
       expect(result).toHaveProperty('status', 'PENDING');
       expect(mockPrisma.teamInvitation.create).toHaveBeenCalled();
+
+      // Flush microtasks so the fire-and-forget mailer.send call resolves
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(mockedMailerSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: player.email,
+          variables: expect.objectContaining({
+            acceptUrl: `https://capyhoops.com/invite/${invitation.token}`,
+          }),
+        })
+      );
+    });
+
+    it('uses PUBLIC_APP_URL env var for invite link when set', async () => {
+      const previous = process.env.PUBLIC_APP_URL;
+      process.env.PUBLIC_APP_URL = 'https://staging.capyhoops.com';
+      try {
+        const coach = createCoach();
+        const player = createPlayer();
+        const league = createLeague();
+        const season = createSeason({ leagueId: league.id });
+        const team = createTeam({ seasonId: season.id });
+        const headCoachRole = createTeamRole({ teamId: team.id, type: 'HEAD_COACH' });
+        const coachStaff = createTeamStaff({ teamId: team.id, userId: coach.id, roleId: headCoachRole.id });
+        const invitation = createInvitation({ teamId: team.id, playerId: player.id, invitedById: coach.id });
+
+        (mockPrisma.team.findUnique as jest.Mock).mockResolvedValue(team);
+        (mockPrisma.user.findUnique as jest.Mock).mockResolvedValue(player);
+        (mockPrisma.teamStaff.findMany as jest.Mock).mockResolvedValue([{ ...coachStaff, role: headCoachRole }]);
+        (mockPrisma.teamMember.findUnique as jest.Mock).mockResolvedValue(null);
+        (mockPrisma.teamInvitation.findFirst as jest.Mock).mockResolvedValue(null);
+        (mockPrisma.teamInvitation.create as jest.Mock).mockResolvedValue({
+          ...invitation,
+          team: { id: team.id, name: team.name, season: { id: season.id, name: season.name, league: { id: league.id, name: league.name } } },
+          player: { id: player.id, name: player.name, email: player.email },
+          invitedBy: { id: coach.id, name: coach.name, email: coach.email },
+        });
+
+        await InvitationService.createInvitation(team.id, { playerId: player.id, expiresInDays: 7 }, coach.id);
+
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(mockedMailerSend).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: expect.objectContaining({
+              acceptUrl: `https://staging.capyhoops.com/invite/${invitation.token}`,
+            }),
+          })
+        );
+      } finally {
+        if (previous === undefined) delete process.env.PUBLIC_APP_URL;
+        else process.env.PUBLIC_APP_URL = previous;
+      }
     });
 
     it('does not surface email send failures to the caller', async () => {

--- a/backend/tests/services/mailer.test.ts
+++ b/backend/tests/services/mailer.test.ts
@@ -144,6 +144,7 @@ describe('invitationTemplate', () => {
     inviterName: 'Phil',
     message: 'Welcome aboard!',
     expiresAt: '2026-07-01',
+    acceptUrl: 'https://capyhoops.com/invite/abc123',
   };
 
   it('subject includes team name', () => {
@@ -161,6 +162,18 @@ describe('invitationTemplate', () => {
     expect(html).not.toContain('italic');
   });
 
+  it('html includes acceptUrl as CTA button and plaintext fallback', () => {
+    const html = invitationTemplate.html(vars);
+    expect(html).toContain('https://capyhoops.com/invite/abc123');
+    expect(html).toContain('Accept Invitation');
+  });
+
+  it('html falls back to generic copy when acceptUrl is missing', () => {
+    const html = invitationTemplate.html({ ...vars, acceptUrl: '' });
+    expect(html).not.toContain('Accept Invitation');
+    expect(html).toContain('Open the CapyHoops app');
+  });
+
   it('text includes all key fields', () => {
     const text = invitationTemplate.text(vars);
     expect(text).toContain('Bulls');
@@ -171,6 +184,17 @@ describe('invitationTemplate', () => {
   it('text omits message block when message is empty', () => {
     const text = invitationTemplate.text({ ...vars, message: '' });
     expect(text).not.toContain('"');
+  });
+
+  it('text includes acceptUrl when provided', () => {
+    const text = invitationTemplate.text(vars);
+    expect(text).toContain('https://capyhoops.com/invite/abc123');
+  });
+
+  it('text falls back to generic copy when acceptUrl is missing', () => {
+    const text = invitationTemplate.text({ ...vars, acceptUrl: '' });
+    expect(text).not.toContain('https://');
+    expect(text).toContain('Open the CapyHoops app');
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds a CTA button + plaintext link to the invitation email pointing at `https://capyhoops.com/invite/<token>`
- Closes the deferred AC from #30 (wire invite URL into SES templates now that #131 SES mailer shipped)
- Code-only change — does NOT enable actual email delivery (still blocked on SES infra apply behind #136)

## Why
After #130 + #131 merged, recipients of invitation emails saw:
> Open the CapyHoops app to accept or decline your invitation.

…with no link to the accept screen that exists at `web/app/invite/[token]/`. This PR adds the missing CTA so the deep-link → mobile app fallback flow actually starts from the email.

## Changes
- `invitation-service.ts`: builds `acceptUrl = {PUBLIC_APP_URL}/invite/{token}` and passes it into template vars. Falls back to `https://capyhoops.com` if `PUBLIC_APP_URL` env var is unset.
- `invitation.ts` template: renders the CTA in HTML (styled button + plaintext link) and the URL in plaintext text. Falls back to the prior generic copy when `acceptUrl` is absent — so any other callers don't regress.
- `env.example`: documents `PUBLIC_APP_URL`.
- Tests: +5 (4 template variants asserting URL present/absent in html and text; 1 invitation-service test asserting env-var override works).

## Test plan
- [x] Backend `npm test`: 846 passing (was 841; +5)
- [x] Backend `npm run type-check`: clean
- [ ] CI green
- [ ] Manual: after SES infra apply (separate PR), send a real invite to a verified sandbox address, click the CTA, confirm it opens the mobile app via Universal Link (once AASA values are filled in — B1)

## Production deploy notes
- ECS task needs `PUBLIC_APP_URL=https://capyhoops.com` (or omit — defaults to that)
- No DB migration
- No breaking changes to existing template callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)