### PR TITLE
fix(web): set iOS Team ID in AASA for Universal Links

### DIFF
--- a/web/public/.well-known/apple-app-site-association
+++ b/web/public/.well-known/apple-app-site-association
@@ -3,7 +3,7 @@
     "apps": [],
     "details": [
       {
-        "appIDs": ["XXXXXXXXXX.com.bballtracker.mobile"],
+        "appIDs": ["2JV3V89598.com.bballtracker.mobile"],
         "components": [
           {
             "/": "/invite/*",


### PR DESCRIPTION
## Summary
- Fills `XXXXXXXXXX` → `2JV3V89598` (real Apple Team ID) in `web/public/.well-known/apple-app-site-association`
- Unblocks iOS Universal Links for the invite-accept deep-link flow

## Why
The placeholder shipped in #130. Without a real Team ID, iOS fails Universal Link validation when fetching the AASA file from capyhoops.com, so tapping an invite-email link lands in Safari instead of opening the CapyHoops app.

## Android note
`assetlinks.json` still has its `REPLACE_WITH_PRODUCTION_SIGNING_CERT_SHA256_FINGERPRINT` placeholder. Android signing isn't set up yet — until then, Android Universal Links will silently fall through to the browser, which is the desired behavior. Filing a follow-up issue to track the Android setup once a production keystore exists.

## Test plan
- [ ] CI passes (JSON validity)
- [ ] After deploy: `curl -s https://capyhoops.com/.well-known/apple-app-site-association | jq .applinks.details[0].appIDs[0]` returns `"2JV3V89598.com.bballtracker.mobile"`
- [ ] Manual: send a real invite email (once SES infra applies), tap link on iPhone with app installed → app opens (not Safari)

🤖 Generated with [Claude Code](https://claude.com/claude-code)