### PR TITLE
chore(mobile): gitignore EAS credentials.json + credentials/

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -51,6 +51,10 @@ android/
 .env.local
 .env.*.local
 
+# EAS credentials (downloaded by `eas credentials`) — never commit
+credentials.json
+credentials/
+
 # TypeScript
 *.tsbuildinfo
 


### PR DESCRIPTION
## Summary
- Adds explicit ignore rules in `mobile/.gitignore` for `credentials.json` and `credentials/`
- Caught while filling iOS Team ID in #138 — user downloaded EAS credentials, which created `mobile/credentials.json`, `mobile/credentials/ios/dist-cert.p12` (iOS signing private key!), and `mobile/credentials/ios/profile.mobileprovision` locally

## Why
- `credentials.json` had no ignore rule at all — would have been committed by `git add .` or similar
- The iOS cert + profile were ignored only by accident (matched the `ios/` rule on line 46, intended for the native `ios/` build dir from `expo prebuild`)

## Verification
Before:
- `git check-ignore -v mobile/credentials.json` → no match
- `git check-ignore -v mobile/credentials/ios/dist-cert.p12` → matches `ios/` (accidental)

After:
- All three files match the new explicit `credentials.json` / `credentials/` rules

Nothing was tracked; this is preventive.

## Followup (not in this PR)
User will delete the local files after this merges since they only needed to extract the iOS Team ID. EAS keeps credentials on their servers — no local copy needed for normal builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)