### PR TITLE
docs: sync top-of-file claims + add web/README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Basketball Tracker is a monorepo with a React Native/Expo mobile app and Node.js/TypeScript backend. It uses event-driven architecture with Kafka and Flink for real-time game tracking and statistics.
+Basketball Tracker is a monorepo with three packages: a React Native/Expo mobile app, a Node.js/TypeScript backend, and a Next.js web app at `web/` that hosts the public `capyhoops.com/invite/<token>` accept flow (deep-links into mobile via Universal Links). It uses event-driven architecture with Kafka and Flink for real-time game tracking and statistics.
 
 ## Common Commands
 
@@ -21,14 +21,23 @@ npm run prisma:generate  # Generate Prisma client after schema changes
 npm run prisma:migrate   # Run database migrations
 npm run prisma:studio    # Open Prisma Studio GUI
 ```
+**After pulling main**, run `npm install` in `backend/` if you see TS2307 errors on `@aws-sdk/client-sesv2` or similar — the SES mailer landing in #131 added new deps that the daemon won't notice without a fresh install.
 
 ### Mobile (`/mobile`)
 ```bash
-npm start       # Start Expo dev server
-npm run ios     # Run on iOS simulator
-npm run android # Run on Android emulator
+npx expo run:ios            # Build + run on iOS simulator (preferred — native modules need this)
+npx expo run:android        # Build + run on Android emulator
+npm run lint                # ESLint check
+npm run type-check          # Type check
+```
+**Do not use** `npm start` / `npx expo start` with this project — several native modules (Sentry, Reanimated, etc.) require a custom dev client built via `expo run:*`, not Expo Go.
+
+### Web (`/web` — Next.js)
+```bash
+npm install     # First-time setup
+npm run dev     # Local dev server on http://localhost:3000
 npm run lint    # ESLint check
-npm run type-check # Type check
+npm run build   # Production build
 ```
 
 ### Mobile Builds (EAS)
@@ -58,8 +67,8 @@ Backend API (Node.js/Express)
 ```
 
 ### Backend Structure (`/backend/src/`)
-- **api/**: Route handlers organized by resource (auth, games, teams, leagues, players, invitations)
-- **services/**: Business logic layer (game-service.ts, team-service.ts, etc.)
+- **api/**: Route handlers organized by resource (auth, games, teams, leagues, players, invitations, seasons, stats, uploads, middleware). `invitations/public-routes.ts` exposes the unauthenticated token lookup + accept used by the web invite page.
+- **services/**: Business logic layer (game-service.ts, team-service.ts, etc.) plus `mailer/` (Mailer interface + FakeMailer + SesMailer + templates) shipped in #131
 - **kafka/**: Kafka producers/consumers for event streaming
 - **websocket/**: Socket.io handlers for real-time updates
 - **models/**: Prisma ORM models
@@ -98,7 +107,7 @@ issue #26 for the Redis adapter follow-up.
 - Event-driven: Kafka for game events, Flink for real-time aggregation
 - Real-time: Socket.io WebSocket for live game updates
 - State management: Zustand (client) + TanStack Query (server state) in mobile
-- Authentication: JWT + WorkOS
+- Authentication: WorkOS (AuthKit). JWT is the session token format — WorkOS is the identity provider.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ bball-tracker/
 ### Backend
 ```bash
 npm run dev                # Start dev server with hot reload
-npm test                   # Run all tests (790 tests across 47 suites)
+npm test                   # Run all Jest tests
 npm test -- --coverage     # Run with coverage (thresholds enforced in CI)
 npm run type-check         # TypeScript type checking
 npx prisma migrate dev     # Run database migrations
@@ -140,7 +140,7 @@ npx prisma studio          # Open database GUI
 ### Mobile
 ```bash
 npx expo run:ios                       # Build and run on iOS simulator
-npm test                               # Run all tests (311 tests across 28 suites)
+npm test                               # Run all Jest tests
 npm run type-check                     # TypeScript type checking
 npx expo export --platform ios         # Verify Metro bundle (also run in CI)
 ```

--- a/backend/README.md
+++ b/backend/README.md
@@ -4,7 +4,7 @@ Node.js/TypeScript backend API for the Basketball Tracker application.
 
 ## Tech Stack
 
-- **Runtime**: Node.js 18+
+- **Runtime**: Node.js 22+
 - **Framework**: Express
 - **Language**: TypeScript
 - **Database**: PostgreSQL (via Prisma ORM)
@@ -12,13 +12,14 @@ Node.js/TypeScript backend API for the Basketball Tracker application.
 - **Event Streaming**: Kafka (kafkajs)
 - **Real-time**: Socket.io
 - **Validation**: Zod
-- **Authentication**: JWT
+- **Authentication**: WorkOS (AuthKit) — JWT is the session token format only
+- **Email**: AWS SES via the `Mailer` interface (FakeMailer in dev/test)
 
 ## Setup
 
 ### Prerequisites
 
-- Node.js 18+ and npm
+- Node.js 22+ and npm
 - PostgreSQL database (local or Docker)
 - Redis (local or Docker)
 
@@ -95,7 +96,7 @@ To modify the database:
 
 ## API Documentation
 
-API documentation will be available at `/api/docs` (to be implemented).
+API routes are organized by resource under `src/api/<resource>/`. See [`docs/automation/daily-upgrade-scan.md`](../docs/automation/daily-upgrade-scan.md) and the per-resource test suites under `tests/api/` for working examples of every endpoint.
 
 ## Testing
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -16,10 +16,9 @@ React Native mobile application built with Expo for iOS and Android.
 
 ### Prerequisites
 
-- Node.js 18+
-- Expo CLI (`npm install -g expo-cli`)
-- iOS Simulator (for macOS) or Android Emulator
-- Physical device with Expo Go app (optional)
+- Node.js 22+
+- Xcode (for iOS Simulator) on macOS, or Android Studio for the Android Emulator
+- EAS CLI (`npx eas` works via the local dev dep — no global install needed)
 
 ### Installation
 
@@ -28,20 +27,17 @@ React Native mobile application built with Expo for iOS and Android.
 npm install
 ```
 
-2. Start the development server:
+2. Run on iOS (builds the dev client — needed for native modules like Sentry):
 ```bash
-npm start
+npx expo run:ios
 ```
 
-3. Run on iOS:
+3. Run on Android:
 ```bash
-npm run ios
+npx expo run:android
 ```
 
-4. Run on Android:
-```bash
-npm run android
-```
+**Do not use** `npm start` / `npx expo start` with this project. Several native modules (Sentry, Reanimated, etc.) require a custom dev client; the legacy Expo Go flow does not work here. See `npx expo run:ios --help` for device-selection flags.
 
 ## Project Structure
 

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,56 @@
+# Basketball Tracker Web
+
+Next.js web app served at `https://capyhoops.com`. Hosts the public invitation accept flow (`/invite/<token>`) that emails link to and the `.well-known/` Universal Link assets that route into the mobile app when installed.
+
+## Tech Stack
+
+- **Framework**: Next.js 15 (App Router)
+- **React**: 19
+- **Language**: TypeScript
+- **Hosting**: TBD (Vercel/CloudFront — not yet deployed as of 2026-05-25)
+
+## Setup
+
+### Prerequisites
+- Node.js 22+
+
+### Install & run
+```bash
+npm install
+npm run dev     # http://localhost:3000
+npm run lint
+npm run build   # production build
+```
+
+## Routes
+
+| Path | Purpose |
+|---|---|
+| `/` | Marketing landing (minimal placeholder) |
+| `/invite/<token>` | Public invitation accept page. Fetches token state from the backend, deep-links to the mobile app via Universal Links, falls back to web accept if the app isn't installed. |
+| `/.well-known/apple-app-site-association` | iOS Universal Link assoc. **Team ID `2JV3V89598`** wired in #138. |
+| `/.well-known/assetlinks.json` | Android Universal Link assoc. Placeholder fingerprint — tracked in #139 until Android signing is set up. |
+
+## How the invite flow works
+
+1. Coach creates invitation → backend (#131 mailer) sends an email with a link to `https://capyhoops.com/invite/<token>`.
+2. Recipient taps the link:
+   - **iOS with app installed** → Universal Link routes directly into `mobile/app/invite/[token].tsx`.
+   - **Android with app installed (after Android signing setup, #139)** → same.
+   - **No app installed / desktop** → this Next.js page renders. Token state (PENDING / EXPIRED / ACCEPTED / etc.) is fetched from `backend/src/api/invitations/public-routes.ts`. User can accept inline or get the App Store / Play Store link.
+
+## Configuration
+
+No env vars required for local dev. In production:
+- The backend's `PUBLIC_APP_URL` must point at this site (`https://capyhoops.com`) so invitation emails embed the right CTA URL — see `backend/env.example`.
+
+## Tests
+
+No test framework configured yet. Tracked in #51 follow-up; bootstrap Vitest + RTL before adding more interactive flows.
+
+## Related
+
+- Backend invite endpoints: `backend/src/api/invitations/public-routes.ts`
+- Backend mailer + template: `backend/src/services/mailer/templates/invitation.ts`
+- Mobile counterpart screen: `mobile/app/invite/[token].tsx`
+- Issue tracking the Android fingerprint: #139


### PR DESCRIPTION
## Summary
Brings the high-impact contributor-facing docs in line with what's actually shipped today (post #131 SES, #130 web invite accept, #138 iOS Team ID). Combines B4 (one-line npm-install gotcha note) and B8 (top-5 doc updates from the docs-sync audit) in one focused PR.

## Changes
- **CLAUDE.md**: web/ in project overview, mobile commands switch to `npx expo run:ios`, new Web section, backend structure refresh, WorkOS not "JWT + WorkOS", npm-install gotcha note
- **backend/README.md**: Node 22+, WorkOS auth, drop "API docs to be implemented", add SES tech-stack line
- **mobile/README.md**: drop `expo-cli` + Expo Go; setup points at `npx expo run:*`; Node 22+
- **web/README.md** (new): from-scratch stub — tech stack, invite flow, AASA/assetlinks state, what's not yet wired
- **README.md**: drop hardcoded test-count parentheticals that drift every PR

## Deferred (separate PRs)
Per the audit's plan, these stay open as B-deferred:
- `mobile/SETUP.md` + `TESTING.md` rewrites
- `docs/architecture/overview.md` (auth, Sentry, SES, web)
- `docs/development/git-workflow.md` + `release-strategy.md` (`develop` branch is referenced but not used)
- `docs/api/` population

## Test plan
- [ ] CI green (markdown only, no code changes)
- [ ] Manual: scan each updated file in the diff for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)