### PR TITLE
feat(infra): add PUBLIC_APP_URL env var to ECS task

### DIFF
--- a/infra/task-definition.json
+++ b/infra/task-definition.json
@@ -27,7 +27,8 @@
         { "name": "SENTRY_ENVIRONMENT", "value": "production" },
         { "name": "SENTRY_RELEASE", "value": "SENTRY_RELEASE_PLACEHOLDER" },
         { "name": "AWS_SES_REGION", "value": "us-east-1" },
-        { "name": "SES_FROM_ADDRESS", "value": "noreply@mail.capyhoops.com" }
+        { "name": "SES_FROM_ADDRESS", "value": "noreply@mail.capyhoops.com" },
+        { "name": "PUBLIC_APP_URL", "value": "https://capyhoops.com" }
       ],
       "secrets": [
         { "name": "DATABASE_URL", "valueFrom": "arn:aws:secretsmanager:us-east-1:982343512143:secret:bball-tracker-production/database-url-1QlcXz" },


### PR DESCRIPTION
## Summary
Sets \`PUBLIC_APP_URL=https://capyhoops.com\` on the production ECS task so the SES invitation template (PR #137) generates the correct accept link in real prod sends.

## Context — SES infra applied today
- \`terraform apply\` for \`infra/ses.tf\` ran successfully (was blocked on #136 / #53, both now fixed)
- SES domain identity \`mail.capyhoops.com\` is now PENDING in AWS with DKIM CNAMEs propagating in Route53 — auto-flips to SUCCESS as DNS propagates (~5-15 min)
- \`AWS_SES_REGION\` and \`SES_FROM_ADDRESS\` were already in this file from #131 — the backend was already trying to use SesMailer, but sends were failing silently because the SES domain didn't exist in AWS until this apply

## Diff
Single env var added. \`PUBLIC_APP_URL\` matches the in-code default (\`https://capyhoops.com\`) from #137, but worth setting explicitly so production config is self-documenting and a future PUBLIC_APP_URL change here doesn't require a code default change.

## Account state
- SES is still in sandbox mode (\`ProductionAccessEnabled: false\`)
- A verification email was sent to deasystephen@gmail.com — once verified, that becomes the first valid recipient for end-to-end testing
- Production-access form submission is a separate manual task (1-5 day approval)

## Test plan
- [ ] CI green
- [ ] After merge, the Build & Deploy to ECS workflow rolls a new task revision and the service picks it up
- [ ] Once SES domain status flips to SUCCESS + deasystephen@gmail.com verified: send a real invitation to that address and confirm receipt + click-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)