### PR TITLE
chore(deps): bump mobile patch deps (2026-05-26)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -34,7 +34,7 @@
         "expo-splash-screen": "^55.0.21",
         "expo-status-bar": "^55.0.6",
         "expo-updates": "^55.0.24",
-        "i18next": "^26.2.0",
+        "i18next": "^26.3.0",
         "lottie-react-native": "^7.3.8",
         "moti": "^0.30.0",
         "react": "^19.2.6",
@@ -11676,9 +11676,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.2.0.tgz",
-      "integrity": "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.0.tgz",
+      "integrity": "sha512-gHSgGpUXVmuqE2El1W61DmxeyeTlFfZgdJRWMo9jScAn5pu7TuTuiccb1zh3E2J9hEBVGJ23+96x0ieBhfuIHA==",
       "funding": [
         {
           "type": "individual",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -41,7 +41,7 @@
     "expo-splash-screen": "^55.0.21",
     "expo-status-bar": "^55.0.6",
     "expo-updates": "^55.0.24",
-    "i18next": "^26.2.0",
+    "i18next": "^26.3.0",
     "lottie-react-native": "^7.3.8",
     "moti": "^0.30.0",
     "react": "^19.2.6",


### PR DESCRIPTION
Daily upgrade scan — mobile auto-fix batch.

| Package | From   | To     |
| ------- | ------ | ------ |
| i18next | 26.2.0 | 26.3.0 |

No CVEs addressed (`npm audit` reports only low/moderate, no high/critical). Bump is within existing caret range, so only package.json and package-lock.json are touched.

Quality gates (run locally):
- `npm run type-check` ✅
- `npm test` ✅ (401/401 passing)
- `npx expo export --platform ios` ✅

Auto-merge enabled — will squash once CI passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgJeQovziQ9iho9j3sLcxS)_