### PR TITLE
chore(deps): bump mobile patch deps (2026-05-28)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,14 +8,14 @@
       "name": "mobile",
       "version": "1.0.0",
       "dependencies": {
-        "@amplitude/analytics-react-native": "^1.5.54",
+        "@amplitude/analytics-react-native": "^1.5.55",
         "@amplitude/analytics-types": "^2.11.1",
         "@expo-google-fonts/inter": "^0.4.2",
         "@expo-google-fonts/oswald": "^0.4.2",
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/datetimepicker": "^8.6.0",
-        "@sentry/react-native": "^8.12.0",
+        "@sentry/react-native": "^8.13.0",
         "@tanstack/react-query": "^5.100.14",
         "axios": "^1.16.1",
         "babel-preset-expo": "^55.0.22",
@@ -50,7 +50,7 @@
         "react-native-worklets": "^0.7.4",
         "socket.io-client": "^4.8.3",
         "zod": "^4.4.3",
-        "zustand": "^5.0.13"
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@testing-library/react-native": "^13.3.3",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@amplitude/analytics-react-native": {
-      "version": "1.5.54",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.5.54.tgz",
-      "integrity": "sha512-M1X20Xr/o2+NPXgGoHgT4Ri5OIkC8O6GyQJW22/xkC0zv/5sGK9h/5Dzx/2BpEaSIWFzlKysXa8h4c1+xLEHoQ==",
+      "version": "1.5.55",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.5.55.tgz",
+      "integrity": "sha512-67JgbcF6RBeF4m+FtYoHBhbtvTamdvo4prNuE/g1bLmgYNV/tvY+C2FRcSlIdzgowBn3T2gHHiSgI7xqUBQ7Og==",
       "license": "MIT",
       "dependencies": {
         "@amplitude/analytics-core": "2.48.2",
@@ -6624,9 +6624,9 @@
       }
     },
     "node_modules/@sentry/cli": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.4.2.tgz",
-      "integrity": "sha512-8HOEe8y4ZtSxBhABSq4fzGgWc1PAR15ptfhrBwxTaqgXAN6CUsPCC/uvdO4gtgo8zKFkD0E5n34YY09tEXJGRg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.4.3.tgz",
+      "integrity": "sha512-sUhfoIWwkVdM2SVtUdIgfY/3p1z369dYYNOZqPjB/7mpiv4owVVS0BD2Aedx8LdBJaTzRcIzSJMhuJ6vcIiSCg==",
       "hasInstallScript": true,
       "license": "FSL-1.1-MIT",
       "dependencies": {
@@ -6642,20 +6642,20 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@sentry/cli-darwin": "3.4.2",
-        "@sentry/cli-linux-arm": "3.4.2",
-        "@sentry/cli-linux-arm64": "3.4.2",
-        "@sentry/cli-linux-i686": "3.4.2",
-        "@sentry/cli-linux-x64": "3.4.2",
-        "@sentry/cli-win32-arm64": "3.4.2",
-        "@sentry/cli-win32-i686": "3.4.2",
-        "@sentry/cli-win32-x64": "3.4.2"
+        "@sentry/cli-darwin": "3.4.3",
+        "@sentry/cli-linux-arm": "3.4.3",
+        "@sentry/cli-linux-arm64": "3.4.3",
+        "@sentry/cli-linux-i686": "3.4.3",
+        "@sentry/cli-linux-x64": "3.4.3",
+        "@sentry/cli-win32-arm64": "3.4.3",
+        "@sentry/cli-win32-i686": "3.4.3",
+        "@sentry/cli-win32-x64": "3.4.3"
       }
     },
     "node_modules/@sentry/cli-darwin": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.4.2.tgz",
-      "integrity": "sha512-MMCkBxj8l5IolwJyf7mv5v/rKOdZS8YCVmXUzv+H75j28j2lvLfsScWh0YaRkzv6+ATYkG1Z5g2J1alv91OuYQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.4.3.tgz",
+      "integrity": "sha512-KUeP9d0rQ9L/A4SU9U6K8fMeRaWLV24FVH9JE6V6tbi4S9feJwKjfXXCpsqTk87Do5k0sohaz4SFiOkbypePLA==",
       "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
@@ -6666,9 +6666,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.4.2.tgz",
-      "integrity": "sha512-oLnskL/TD/SkcqZ8xSPSSZfSSTEswiyx/hqtENmzR8aKIEiyZlDD8sH2h5CCevVDTGO2WDbOWZQCKFlWtIWP1Q==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.4.3.tgz",
+      "integrity": "sha512-3dPFWfaB5g31KnwKuQwHboXfh9+m2Gzk/i6eoQsbMamGQWVguQRHn1mZ1PmGykEMvWH3YFopMcfjPt4euNG/ag==",
       "cpu": [
         "arm"
       ],
@@ -6684,9 +6684,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.4.2.tgz",
-      "integrity": "sha512-xsA7DjZkFBBu5WLINimWv50h+jSxS5+F+6DxMYcgXkYZ4pbEWToG+IcBaZGsqXKNIYIUyd7hQvqCH/LFNAqShA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.4.3.tgz",
+      "integrity": "sha512-DPu03ywFtmBC/mtQ2+oWZDPHn9hYPLCYNgSxgBkHKrbYcgv4uJLTrl84at3NI/CU8VnpUbx+oeq03chmezZBPA==",
       "cpu": [
         "arm64"
       ],
@@ -6702,9 +6702,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-i686": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.4.2.tgz",
-      "integrity": "sha512-AD8l7GGwGIixALSYeIBWsAqLQgi90df4Z3XIGPOqkJWSg5xh40Qk0r1zHXUwayGabtY8YgDlcAUS1CQ+1Tqu9Q==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.4.3.tgz",
+      "integrity": "sha512-7Jvx+TZLWJJiKCua6YRDXnE+juSuHP4Tw80HzVtEGTgrgGVJTn2VRCwgDQjPKNrRvjeOK7M6/TnFECOqa750xw==",
       "cpu": [
         "x86",
         "ia32"
@@ -6721,9 +6721,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-x64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.4.2.tgz",
-      "integrity": "sha512-H73CL6EIdYi75iEUpGF26ojIZk+vTvAKc3Yj4uXRup2kmOikM9uliRlZRgmVsDExApgCDuzFrLzdKFYbJJ03aA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.4.3.tgz",
+      "integrity": "sha512-2opnMFIx/c1lRqW0SiKMy2q3ChuB7tCadfS8WEJKAMdfQLQrSQmyW/9fhBGK9fDSMqGFVoxU6aaSS89GKnkN8g==",
       "cpu": [
         "x64"
       ],
@@ -6739,9 +6739,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-arm64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.4.2.tgz",
-      "integrity": "sha512-fjBS2to5oJpfWmK5l14fZgoRfTOAZIFqa4Ej+urOLU3NH4etehDRHgGMcxPPLjoVkkAC6M/auf1+rQc1tt0olg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.4.3.tgz",
+      "integrity": "sha512-7Nup5qlbogV99zGcgreTqkUy3IRK1C4T3NYTDVO4iu36E31V0pOqyjqh5WSS/6jf9TkDugmkieSv+UjfKwZMFQ==",
       "cpu": [
         "arm64"
       ],
@@ -6755,9 +6755,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-i686": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.4.2.tgz",
-      "integrity": "sha512-20jpyvG8g7QUSa+zBFXEPhvMf5EB4YILCZb1xhGwEZsfwUPN02qRoCwpY018/jKimxEJRGpCHhxC9ybUceQaNg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.4.3.tgz",
+      "integrity": "sha512-ENQtxeeH/jc2FRDSbPDs7RSy4+27RFFa8SxYnQUjWVCxCTgh0w3lfE61RzqWcvQ+4D04g/tPbb3TKMtTQIdcRw==",
       "cpu": [
         "x86",
         "ia32"
@@ -6772,9 +6772,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-x64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.4.2.tgz",
-      "integrity": "sha512-FfFQzBkTvyU7AafzaOxhAFlmXKMe+9aXKNjnvA4VRHeBExdS71ZHKcPn44rZppoDLHWCrR2nm35WZG4so+jmSA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.4.3.tgz",
+      "integrity": "sha512-pd69Woj4U1L/T+t0kmxNx+1GM096tcQg1NQH34IqwrE+tRiui0IKW3euu2E3bcu4ckJWlNmNHwXpONgZELK4EQ==",
       "cpu": [
         "x64"
       ],
@@ -6808,12 +6808,12 @@
       }
     },
     "node_modules/@sentry/expo-upload-sourcemaps": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/expo-upload-sourcemaps/-/expo-upload-sourcemaps-8.12.0.tgz",
-      "integrity": "sha512-SU32x+Le8jOB12T3gfcihd+X+gCYBYtaS6ijQyx9vPo6xGBKumET5DF+MjNCnrtHxqb0yQROeR48y0qfh51MWg==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/expo-upload-sourcemaps/-/expo-upload-sourcemaps-8.13.0.tgz",
+      "integrity": "sha512-WzbQhqOrOKOnhYyYdN0sTbcxE78QfvzUpDXbOHxq9nzNu3DsSYkKqyuuGWiD/um67KqzHZHy7kjwXyHwr0UkhA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/cli": "3.4.2"
+        "@sentry/cli": "3.4.3"
       },
       "bin": {
         "expo-upload-sourcemaps": "cli.js"
@@ -6868,18 +6868,17 @@
       }
     },
     "node_modules/@sentry/react-native": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.12.0.tgz",
-      "integrity": "sha512-ZQMfi2cw3tZuGcdD4mU4yJWu84c+YO0iu+hNuPDwKqVMJBofaU9wE3F0VBOqI7lwzuxmy6m0LTJVpAkKUQjOyg==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.13.0.tgz",
+      "integrity": "sha512-4cXHjbZ5ioXWRIUDAqz5S6JC3jjm+/rElXP9cQcPj3e5Shh5mrV32YMgHljbOuICMkMxgqe0QOtMWL++T9DYGA==",
       "license": "MIT",
       "dependencies": {
         "@sentry/babel-plugin-component-annotate": "5.3.0",
         "@sentry/browser": "10.53.1",
-        "@sentry/cli": "3.4.2",
+        "@sentry/cli": "3.4.3",
         "@sentry/core": "10.53.1",
-        "@sentry/expo-upload-sourcemaps": "8.12.0",
-        "@sentry/react": "10.53.1",
-        "@sentry/types": "10.53.1"
+        "@sentry/expo-upload-sourcemaps": "8.13.0",
+        "@sentry/react": "10.53.1"
       },
       "bin": {
         "sentry-eas-build-on-complete": "scripts/eas-build-hook.js",
@@ -6903,18 +6902,6 @@
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.53.1.tgz",
       "integrity": "sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/react-native/node_modules/@sentry/types": {
-      "version": "10.53.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.53.1.tgz",
-      "integrity": "sha512-RpVZK6kK/2920PMIqITTyJPLeddfFsLbJcIjO9GDTC8PPQY8C/I4HCBTZetHfhVtx70HM9wAgBy3tKs5U8qsCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.53.1"
-      },
       "engines": {
         "node": ">=18"
       }
@@ -17820,9 +17807,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -18507,9 +18494,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
-      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,14 +15,14 @@
     "eas-build-on-success": "node scripts/sentry-upload-sourcemaps.js"
   },
   "dependencies": {
-    "@amplitude/analytics-react-native": "^1.5.54",
+    "@amplitude/analytics-react-native": "^1.5.55",
     "@amplitude/analytics-types": "^2.11.1",
     "@expo-google-fonts/inter": "^0.4.2",
     "@expo-google-fonts/oswald": "^0.4.2",
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "^8.6.0",
-    "@sentry/react-native": "^8.12.0",
+    "@sentry/react-native": "^8.13.0",
     "@tanstack/react-query": "^5.100.14",
     "axios": "^1.16.1",
     "babel-preset-expo": "^55.0.22",
@@ -57,7 +57,7 @@
     "react-native-worklets": "^0.7.4",
     "socket.io-client": "^4.8.3",
     "zod": "^4.4.3",
-    "zustand": "^5.0.13"
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@testing-library/react-native": "^13.3.3",


### PR DESCRIPTION
Lockfile-only patch bumps within existing caret ranges. All within same major; no overrides applied this run.

| Package                            | From    | To      |
| ---------------------------------- | ------- | ------- |
| @amplitude/analytics-react-native  | 1.5.54  | 1.5.55  |
| @sentry/react-native               | 8.12.0  | 8.13.0  |
| zustand                            | 5.0.13  | 5.0.14  |

**Quality gates**
- `npm run type-check` — clean
- `npm test` — 39 suites, 401 tests passed
- `npx expo export --platform ios` — clean

**CVE refs**: none — no open Dependabot high/critical alerts addressed in this batch.

Generated by the Daily Upgrade Scan routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnrvSFWRkur3X8mkqN9XXQ)_