### PR TITLE
chore(deps): bump backend patch deps (2026-05-31)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -49,7 +49,7 @@
         "socket.io-client": "^4.8.3",
         "supertest": "^7.1.3",
         "ts-jest": "^29.4.11",
-        "tsx": "^4.22.3",
+        "tsx": "^4.22.4",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.0"
       }
@@ -8903,9 +8903,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.3",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
-      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -76,7 +76,7 @@
     "socket.io-client": "^4.8.3",
     "supertest": "^7.1.3",
     "ts-jest": "^29.4.11",
-    "tsx": "^4.22.3",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.0"
   }


### PR DESCRIPTION
Caret-range patch bumps caught by the [Daily Upgrade Scan](../blob/main/docs/automation/daily-upgrade-scan.md). Auto-merge enabled.

## Bumps

| Package | From   | To     |
| ------- | ------ | ------ |
| tsx     | 4.22.3 | 4.22.4 |

## CVE refs

None — no open Dependabot alerts in the high/critical bucket for backend.

## Quality gates

- `npm run type-check` — pass
- `npm test` — 846 tests pass, 50 suites

## Deferred items

See the [Deferred dependency upgrades](https://github.com/deasystephen/bball-tracker/issues/77) tracking issue for what this scan intentionally skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MKZQtowJSKTjG8UZiD8PK6)_