### PR TITLE
chore(deps): bump mobile patch deps (2026-06-02)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -37,8 +37,8 @@
         "i18next": "^26.3.0",
         "lottie-react-native": "^7.3.8",
         "moti": "^0.30.0",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "react-i18next": "^17.0.8",
         "react-native": "0.83.4",
         "react-native-confetti-cannon": "^1.5.2",
@@ -55,11 +55,11 @@
       "devDependencies": {
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^29.5.12",
-        "@types/react": "^19.2.15",
+        "@types/react": "^19.2.16",
         "eas-cli": "^18.13.1",
         "jest": "^29.7.0",
         "jest-expo": "^55.0.18",
-        "react-test-renderer": "^19.2.6",
+        "react-test-renderer": "^19.2.7",
         "typescript": "^6.0.3"
       }
     },
@@ -7251,9 +7251,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.15",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
-      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "version": "19.2.16",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
+      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -15678,9 +15678,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15718,15 +15718,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-fast-compare": {
@@ -15775,9 +15775,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT"
     },
     "node_modules/react-native": {
@@ -16268,17 +16268,17 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.6.tgz",
-      "integrity": "sha512-GbS6V23YduFTPiWJ5xICbKEjRcqx1Z90js/V5miqhz7qp/d6xSe9Dd6NjSQODFRdzdsqRMPW82E/sFpPRbY5Mw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.7.tgz",
+      "integrity": "sha512-U4TyPDJ9MsC8rFimXuJum8w40aPc9kbOZYO8Pc2/4A884i8hwJsMNA/JNyuOc/f2/37wHvk7HjpVl1V4re7Dig==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "react-is": "^19.2.6",
+        "react-is": "^19.2.7",
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/redent": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -44,8 +44,8 @@
     "i18next": "^26.3.0",
     "lottie-react-native": "^7.3.8",
     "moti": "^0.30.0",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "react-i18next": "^17.0.8",
     "react-native": "0.83.4",
     "react-native-confetti-cannon": "^1.5.2",
@@ -62,11 +62,11 @@
   "devDependencies": {
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.12",
-    "@types/react": "^19.2.15",
+    "@types/react": "^19.2.16",
     "eas-cli": "^18.13.1",
     "jest": "^29.7.0",
     "jest-expo": "^55.0.18",
-    "react-test-renderer": "^19.2.6",
+    "react-test-renderer": "^19.2.7",
     "typescript": "^6.0.3"
   },
   "expo": {


### PR DESCRIPTION
Caret-range patch bumps surfaced by the Daily Upgrade Scan.

| Package | From | To |
| --- | --- | --- |
| @types/react | 19.2.15 | 19.2.16 |
| react | 19.2.6 | 19.2.7 |
| react-dom | 19.2.6 | 19.2.7 |
| react-test-renderer | 19.2.6 | 19.2.7 |

### Quality gates
- `npm run type-check`: pass
- `npm test`: 401 passed (39 suites)
- `npx expo export --platform ios`: pass

### Dependabot alerts
No high/critical alerts open. Mobile `npm audit` reports 1 low + 22 moderate — all transitives under deferred Expo/RN ecosystem packages tracked in #77.

Auto-merge will fire once required checks pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQnQ92jTfRm6PjBbYxabYv)_