### PR TITLE
chore(deps): bump backend patch deps (2026-06-04)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,7 +24,7 @@
         "express-rate-limit": "^8.5.2",
         "helmet": "^8.2.0",
         "ics": "^3.12.0",
-        "ioredis": "^5.11.0",
+        "ioredis": "^5.11.1",
         "kafkajs": "^2.2.4",
         "pdfkit": "^0.18.0",
         "pg": "^8.21.0",
@@ -6017,9 +6017,9 @@
       "license": "ISC"
     },
     "node_modules/ioredis": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.0.tgz",
-      "integrity": "sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
       "license": "MIT",
       "dependencies": {
         "@ioredis/commands": "1.10.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -42,7 +42,7 @@
     "express-rate-limit": "^8.5.2",
     "helmet": "^8.2.0",
     "ics": "^3.12.0",
-    "ioredis": "^5.11.0",
+    "ioredis": "^5.11.1",
     "kafkajs": "^2.2.4",
     "pdfkit": "^0.18.0",
     "pg": "^8.21.0",


### PR DESCRIPTION
Daily upgrade scan auto-fix bucket.

## Version changes

| Package | From   | To     |
| ------- | ------ | ------ |
| ioredis | 5.11.0 | 5.11.1 |

Patch bumps within the existing caret range (lockfile-only updates).

## Quality gates

- `npm run type-check`: pass
- `npm test`: pass (846/846 across 50 suites)
- Diff guard: only `backend/package.json` and `backend/package-lock.json` modified

## CVE references

None — routine patch bump.

## Notes

`@aws-sdk/client-s3`, `@aws-sdk/client-sesv2`, and `@aws-sdk/s3-request-presigner` patch bumps (3.1058 → 3.1061) were intentionally skipped this round to avoid conflicting with the in-flight Dependabot PR #165 which already targets those packages (3.1058 → 3.1059). They will land via that PR; the slight stale-by-2-patches will be picked up by a follow-up scan.

Companion to the daily upgrade scan log on #78.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ndwEZKwoiWfHGVSoSTpmk)_