### PR TITLE
docs(testing): note pdfkit version bump in M.2

### DIFF
--- a/docs/testing/e2e-test-plan-v2.0.md
+++ b/docs/testing/e2e-test-plan-v2.0.md
@@ -649,7 +649,7 @@ The marquee feature shipped this month. Includes the email path (#131) + web/mob
 - [ ] Pass / Fail / Skipped
 - **Steps:** Game detail → Export Box Score (PDF). OR `curl ...api/v1/games/:gameId/boxscore.pdf`.
 - **Expected:** PDF downloads with both teams' stats lines. Filename has Content-Disposition with proper encoding.
-- **Notes:** Per #46 + memory.
+- **Notes:** Per #46 + memory. **As of #172 the underlying `pdfkit` is 0.19.0 (was 0.18.0)** — eyeball text layout, column alignment, and any custom fonts for rendering regressions.
 
 ### M.3 — Team season stats CSV
 - [ ] Pass / Fail / Skipped


### PR DESCRIPTION
## Summary
One-line note on test plan section M.2 (PDF box score export) flagging that #172 bumped pdfkit from 0.18.0 to 0.19.0.

## Why
0.x minor bumps on rendering libraries can produce subtle layout/font/alignment shifts. The note tells the tester to look specifically for those rather than just verify "a PDF downloaded."

## Test plan
- [x] Markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)