### PR TITLE
chore(deps): bump backend patch deps (2026-06-12)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1066.0",
-        "@aws-sdk/client-sesv2": "^3.1066.0",
-        "@aws-sdk/s3-request-presigner": "^3.1066.0",
+        "@aws-sdk/client-s3": "^3.1067.0",
+        "@aws-sdk/client-sesv2": "^3.1067.0",
+        "@aws-sdk/s3-request-presigner": "^3.1067.0",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "@sentry/node": "^10.57.0",
@@ -162,9 +162,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1066.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1066.0.tgz",
-      "integrity": "sha512-jfJTg6Xbyws8+YF5sVQXgCA01elkenGEYeX6+HQOovu9m/Td1Ln2xcY3lHKetVNltdArp5rykjNd56z7bnA9dw==",
+      "version": "3.1067.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1067.0.tgz",
+      "integrity": "sha512-3f64o9YWzwJ9WzMIC4JlUQiMOm7R/EtkIDyFdj8yaQXuh8SR9ezz2R32UMpvTlVMtpoPan3Uj8oveAHr2UeExw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sesv2": {
-      "version": "3.1066.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1066.0.tgz",
-      "integrity": "sha512-E50B56dRW18AKSonLg/O30Sjbj7VaGrj7JNy+TEejtLTEL35LDJW1yHXOzPZ5h12eXXo9H0fHZxYZVVS1xblIw==",
+      "version": "3.1067.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1067.0.tgz",
+      "integrity": "sha512-rOgc9pUdH6Zh0Aaaa7SDUFqK3+nogqN2Abk1FtDtoZC6StOGtXPTvlIdcyM44hpRBj1ttETmiI/VCWLXKUb2EQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -427,9 +427,9 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1066.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1066.0.tgz",
-      "integrity": "sha512-hgjGUVKggCKcwS+e7HOoHlElQrhz4nlZkMWGKez/Ycjv2qZaQeTZ8Ps7HGOrpqR3KBPWt7iSrOBcOCVoUYYRWw==",
+      "version": "3.1067.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1067.0.tgz",
+      "integrity": "sha512-BXoy6vCLR/ns2a09knkFgs18fX+EozyOsxX/eHwEXH3DgRh/w2z24X3bamU0ouc5DAGQRKmLeRcYKd7YasmcpQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.20",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,9 +27,9 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1066.0",
-    "@aws-sdk/client-sesv2": "^3.1066.0",
-    "@aws-sdk/s3-request-presigner": "^3.1066.0",
+    "@aws-sdk/client-s3": "^3.1067.0",
+    "@aws-sdk/client-sesv2": "^3.1067.0",
+    "@aws-sdk/s3-request-presigner": "^3.1067.0",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@sentry/node": "^10.57.0",


### PR DESCRIPTION
Auto-fix batch from the Daily Upgrade Scan (2026-06-12).

| Package | From | To |
| --- | --- | --- |
| `@aws-sdk/client-s3` | 3.1066.0 | 3.1067.0 |
| `@aws-sdk/client-sesv2` | 3.1066.0 | 3.1067.0 |
| `@aws-sdk/s3-request-presigner` | 3.1066.0 | 3.1067.0 |

Caret-range patch bumps (`current → wanted`, within existing caret).

**No related CVE / Dependabot alerts** for these packages.

## Quality gates
- `npm run type-check` → pass
- `npm test` → 50 suites / 846 tests pass

## Diff guard
Only `backend/package.json` + `backend/package-lock.json` changed.

Auto-merge will be enabled once CI is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_0115P6yshZvtYUF1NYyQKVfV)_