### PR TITLE
chore(deps): bump mobile patch deps (2026-06-12)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mobile",
       "version": "1.0.0",
       "dependencies": {
-        "@amplitude/analytics-react-native": "^1.5.56",
+        "@amplitude/analytics-react-native": "^1.5.57",
         "@amplitude/analytics-types": "^2.11.1",
         "@expo-google-fonts/inter": "^0.4.2",
         "@expo-google-fonts/oswald": "^0.4.2",
@@ -85,9 +85,9 @@
       "license": "MIT"
     },
     "node_modules/@amplitude/analytics-core": {
-      "version": "2.49.0",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.49.0.tgz",
-      "integrity": "sha512-D3CFMADvZOxcQPcd1ak7uRgySA4ySUuJ5BnqfIC11zCulLYsTcOd+z/RQACgzFG7tZbHR6ftdoiGmg0HYEQ5sw==",
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.50.0.tgz",
+      "integrity": "sha512-d8/U5aAHAs6XcpvQYpStxBxMxSwjDajZ0f6wMSwPCfxDGEWqcFaYuRKauh+vrn89D6gWcKi1VZ/tKCyhVby9sg==",
       "license": "MIT",
       "dependencies": {
         "@amplitude/analytics-connector": "^1.6.4",
@@ -98,12 +98,12 @@
       }
     },
     "node_modules/@amplitude/analytics-react-native": {
-      "version": "1.5.56",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.5.56.tgz",
-      "integrity": "sha512-RoXiCDhstg94Hc7eZiCaTBnmDJszmjh2UXqVCCXmhXjAo3hm5S5zKyKg1LmS+vjXU2uWrmnhFIM+pNXAe6nvYg==",
+      "version": "1.5.57",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.5.57.tgz",
+      "integrity": "sha512-JfydxAtEjtF19XUfUawFg7lvJlbYPQ89y48ScvpG1bFDOcYf1mHXwqxKedosBCjmZyqUL2poFXoFt8AFTqBcSA==",
       "license": "MIT",
       "dependencies": {
-        "@amplitude/analytics-core": "2.49.0",
+        "@amplitude/analytics-core": "2.50.0",
         "@amplitude/ua-parser-js": "^0.7.31",
         "@react-native-async-storage/async-storage": "^1.17.11",
         "tslib": "^2.4.1"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,7 +15,7 @@
     "eas-build-on-success": "node scripts/sentry-upload-sourcemaps.js"
   },
   "dependencies": {
-    "@amplitude/analytics-react-native": "^1.5.56",
+    "@amplitude/analytics-react-native": "^1.5.57",
     "@amplitude/analytics-types": "^2.11.1",
     "@expo-google-fonts/inter": "^0.4.2",
     "@expo-google-fonts/oswald": "^0.4.2",


### PR DESCRIPTION
Auto-fix batch from the Daily Upgrade Scan (2026-06-12).

| Package | From | To |
| --- | --- | --- |
| `@amplitude/analytics-react-native` | 1.5.56 | 1.5.57 |

Caret-range patch bump (`current → wanted`, within existing caret).

**No related CVE / Dependabot alerts** for this package.

## Quality gates
- `npm run type-check` → pass
- `npm test` → 39 suites / 401 tests pass
- `npx expo export --platform ios` → bundle exported successfully

## Diff guard
Only `mobile/package.json` + `mobile/package-lock.json` changed.

Auto-merge will be enabled once CI is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_0115P6yshZvtYUF1NYyQKVfV)_