### PR TITLE
fix(ci): serialize ECS deploys and skip them on mobile-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,11 +122,41 @@ jobs:
         working-directory: mobile
         run: npx expo export --platform ios
 
+  detect-changes:
+    name: Detect backend changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Only these paths produce a new backend container image. Mobile-only
+          # changes (e.g. nightly mobile dep bumps) must NOT trigger an ECS
+          # deploy — that just adds noise and needless deploys.
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'infra/**'
+              - 'docker/**'
+              - '.github/workflows/ci.yml'
+
   build-and-deploy:
     name: Build & Deploy to ECS
     runs-on: ubuntu-latest
-    needs: [lint-and-typecheck, test-backend, test-mobile]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [lint-and-typecheck, test-backend, test-mobile, detect-changes]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.detect-changes.outputs.backend == 'true'
+    # Serialize deploys to the shared ECS service. When the nightly upgrade scan
+    # merges several PRs within minutes, concurrent deploy jobs would otherwise
+    # race and the superseded one fails with a misleading "deployment not found /
+    # circuit breaker" error. cancel-in-progress: false so an in-flight
+    # production deploy always runs to completion rather than being cancelled
+    # mid-rollout.
+    concurrency:
+      group: ecs-deploy-production
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

Nightly failure notices from CI. The **Daily Upgrade Scan** merges several PRs to `main` within minutes; the `Build & Deploy to ECS` job had **no concurrency control** and ran on **every** push to `main`, so overlapping deploys raced against the single production ECS service. The superseded deploy then failed with a misleading error:

```
Deployment ecs-svc/… not found after stabilization.
The deployment was likely rolled back by the deployment circuit breaker.
```

The circuit breaker is actually **disabled** — that message is the action's generic guess. Production always ended up healthy on the latest image, so these were **false-alarm failures** (with a latent "which image wins is nondeterministic" risk).

### Evidence
- Failures occur only when ≥2 PRs merge close together (06-11 #178/#179, 06-12 #180). The later deploy wins; the earlier reports failure.
- A lone nightly merge (06-13 #183) passes.
- Overlapping deploy job windows confirmed: 15:12:50–15:22:03 vs 15:14:57–15:21:33.

## Fix

1. **Job-level `concurrency`** (`group: ecs-deploy-production`, `cancel-in-progress: false`) — deploys queue instead of racing; an in-flight production deploy always runs to completion.
2. **`detect-changes` path filter** (`dorny/paths-filter`) — deploy only runs when `backend/**`, `infra/**`, `docker/**`, or the workflow file changed, so mobile-only dep bumps no longer trigger a pointless backend deploy.

## Verification
- Workflow YAML validated with `js-yaml`.
- This PR touches `.github/workflows/ci.yml` (in the deploy filter), so merging it will trigger exactly one deploy — an end-to-end check of the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)