### PR TITLE
fix(deps): stop dependabot bumping Expo-SDK-pinned native modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,21 @@ updates:
       - dependency-name: "expo"
       - dependency-name: "jest"
         versions: [">=30"]
+      # Expo-managed native modules: versions are pinned by the Expo SDK
+      # (expo/bundledNativeModules.json), not by npm. Letting dependabot bump
+      # these ahead of the current SDK breaks the native build (see #175, where
+      # it proposed reanimated 4.4.1 / worklets 0.9.2 against an SDK-55 project
+      # that pins reanimated 4.2.1 / worklets 0.7.4). They move only via an
+      # `expo install` / SDK upgrade. This enforces, at the dependabot level,
+      # the RN-ecosystem deferral already documented as authoritative in
+      # docs/automation/daily-upgrade-scan.md — re-evaluate at each SDK bump.
+      - dependency-name: "@react-native-async-storage/async-storage"
+      - dependency-name: "@react-native-community/datetimepicker"
+      - dependency-name: "react-native-gesture-handler"
+      - dependency-name: "react-native-reanimated"
+      - dependency-name: "react-native-safe-area-context"
+      - dependency-name: "react-native-screens"
+      - dependency-name: "react-native-worklets"
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 


### PR DESCRIPTION
## Why

Dependabot opened **#175** (mobile-minor group) proposing native-module versions **ahead of what Expo SDK 55 supports**:

| Package | Expo SDK 55 pins (= current `main`) | #175 proposed |
|---|---|---|
| react-native-gesture-handler | ~2.30.0 | ~2.32.0 |
| react-native-reanimated | 4.2.1 | 4.4.1 |
| react-native-safe-area-context | ~5.6.2 | ~5.8.0 |
| react-native-screens | ~4.23.0 | ~4.25.2 |
| react-native-worklets | 0.7.4 | ^0.9.2 |

(Source of truth: `mobile/node_modules/expo/bundledNativeModules.json`.)

These are **Expo-managed native modules** — their versions track the Expo SDK, not npm. Bumping them past the SDK pin breaks the native build (the #175 CI failures: lockfile inconsistency → type errors → Jest resolution failures). They should only move via an `expo install` / SDK upgrade.

The daily-upgrade-scan deferral list (`docs/automation/daily-upgrade-scan.md`) **already documents these as "defer all until next Expo SDK upgrade"**, but `dependabot.yml` never enforced it — so dependabot kept opening them. This change closes that gap.

## What

Adds the RN-ecosystem native modules to the `/mobile` dependabot `ignore` list: gesture-handler, reanimated, safe-area-context, screens, worklets, plus async-storage and datetimepicker (same SDK-pinned category).

`react-native-svg` is intentionally **left bumpable** — it has been updating cleanly within the SDK-compatible range (e.g. #147).

## Result
- #175 is being closed (unmergeable by design — SDK-incompatible).
- Dependabot will stop re-proposing these, ending the recurring noise.
- They'll be revisited deliberately at the next Expo SDK upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)