### PR TITLE
docs: accuracy pass across READMEs and the E2E test plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ docker-compose up -d
 ```bash
 cd backend
 npm install
-cp .env.example .env   # Edit with your config
+cp env.example .env   # Edit with your config
 npx prisma generate
 npx prisma migrate dev
 npm run dev

--- a/backend/README.md
+++ b/backend/README.md
@@ -83,7 +83,7 @@ backend/
 
 ## Environment Variables
 
-See `.env.example` for required environment variables.
+See `env.example` for required environment variables.
 
 ## Database
 
@@ -96,7 +96,7 @@ To modify the database:
 
 ## API Documentation
 
-API routes are organized by resource under `src/api/<resource>/`. See [`docs/automation/daily-upgrade-scan.md`](../docs/automation/daily-upgrade-scan.md) and the per-resource test suites under `tests/api/` for working examples of every endpoint.
+API routes are organized by resource under `src/api/<resource>/`. See the per-resource test suites under `tests/api/` for working examples of every endpoint.
 
 ## Testing
 

--- a/docs/testing/e2e-test-plan-v2.0.md
+++ b/docs/testing/e2e-test-plan-v2.0.md
@@ -649,7 +649,7 @@ The marquee feature shipped this month. Includes the email path (#131) + web/mob
 - [ ] Pass / Fail / Skipped
 - **Steps:** Game detail → Export Box Score (PDF). OR `curl ...api/v1/games/:gameId/boxscore.pdf`.
 - **Expected:** PDF downloads with both teams' stats lines. Filename has Content-Disposition with proper encoding.
-- **Notes:** Per #46 + memory. **As of #172 the underlying `pdfkit` is 0.19.0 (was 0.18.0)** — eyeball text layout, column alignment, and any custom fonts for rendering regressions.
+- **Notes:** Per #46 + memory. **As of #172 the underlying `pdfkit` is 0.19.1 (was 0.18.0)** — eyeball text layout, column alignment, and any custom fonts for rendering regressions.
 
 ### M.3 — Team season stats CSV
 - [ ] Pass / Fail / Skipped
@@ -716,7 +716,7 @@ Cross-cuts E, I, J — but worth aggregating here.
 - [ ] Pass / Fail / Skipped
 - **Steps:** (Synthetic) — temporarily break SES creds OR send to an obviously-bounced address.
 - **Expected:** `POST /invitations` still returns 201. Backend logs an error. No 500.
-- **Notes:** Per `invitation-service.ts:168` catch block.
+- **Notes:** Per `invitation-service.ts:171` catch block.
 
 ### O.4 — Per `vars.acceptUrl`: link uses `https://capyhoops.com` not localhost
 - [ ] Pass / Fail / Skipped
@@ -954,3 +954,5 @@ After B3-prod-access lands and production access is granted, this step is no lon
 
 ### D. Plan revision history
 - 2026-05-25: v1 — created post-v2.0-batch (PRs #131, #130, #137, #138, #150). Built #17 on TestFlight.
+- 2026-06-08: M.2 — noted pdfkit version bump (#173).
+- 2026-06-14: accuracy pass — pdfkit note → 0.19.1, invitation-service catch line → :171.

--- a/infra/README.md
+++ b/infra/README.md
@@ -39,7 +39,8 @@ Transactional email is sent from `noreply@mail.capyhoops.com` via AWS SES v2.
    mail.capyhoops.com  TXT  "v=spf1 include:amazonses.com ~all"
    ```
 4. **MX record** routes bounces and complaints back to the SES feedback
-   endpoint (required for bounce/complaint handling):
+   endpoint (required for bounce/complaint handling; the region in the host
+   below is derived from `var.aws_region` in `ses.tf`):
    ```
    mail.capyhoops.com  MX  10 feedback-smtp.us-east-1.amazonses.com
    ```
@@ -73,6 +74,6 @@ addresses.  To request production access:
 | `AWS_SES_REGION` | ECS task definition env | `us-east-1` |
 | `SES_FROM_ADDRESS` | ECS task definition env | `noreply@mail.capyhoops.com` |
 
-Both variables are left blank in `env.example` and in the test environment,
-which causes the backend to fall back to the in-memory `FakeMailer`
-(no real emails sent in dev/test).
+Both variables are pre-filled in `env.example` (with a comment to leave them
+blank in dev/test); leaving them blank causes the backend to fall back to the
+in-memory `FakeMailer` (no real emails sent in dev/test).

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -18,7 +18,7 @@ React Native mobile application built with Expo for iOS and Android.
 
 - Node.js 22+
 - Xcode (for iOS Simulator) on macOS, or Android Studio for the Android Emulator
-- EAS CLI (`npx eas` works via the local dev dep — no global install needed)
+- EAS CLI (`npx eas-cli` works via the local dev dep — no global install needed)
 
 ### Installation
 
@@ -50,8 +50,10 @@ mobile/
 │   └── (tabs)/       # Tab navigation group
 │       ├── _layout.tsx
 │       ├── home.tsx
+│       ├── teams.tsx
 │       ├── games.tsx
 │       ├── stats.tsx
+│       ├── invitations.tsx
 │       └── profile.tsx
 ├── components/       # Reusable UI components
 ├── hooks/            # Custom React hooks
@@ -65,7 +67,7 @@ mobile/
 
 ## Environment Variables
 
-Create an `app.config.js` or update `app.json` to include environment-specific configuration:
+Configure environment-specific settings in the existing `app.config.js` (it already defines the EAS Update URL and an `extra` block):
 
 ```javascript
 export default {

--- a/web/README.md
+++ b/web/README.md
@@ -7,7 +7,7 @@ Next.js web app served at `https://capyhoops.com`. Hosts the public invitation a
 - **Framework**: Next.js 15 (App Router)
 - **React**: 19
 - **Language**: TypeScript
-- **Hosting**: TBD (Vercel/CloudFront — not yet deployed as of 2026-05-25)
+- **Hosting**: TBD (Vercel/CloudFront — not yet deployed as of 2026-06-14)
 
 ## Setup
 


### PR DESCRIPTION
## What

Fixes stale/inaccurate documentation surfaced by a full doc audit (READMEs + E2E test plan). Every change was verified against the current repo.

| File | Fix | Severity |
|---|---|---|
| `README.md` | `cp .env.example .env` → `env.example` (file has no leading dot; command was failing) | HIGH |
| `backend/README.md` | `.env.example` → `env.example`; removed stray daily-upgrade-scan link from API-docs section | HIGH / MED |
| `mobile/README.md` | `npx eas` → `npx eas-cli`; tab list completed to all 6 tabs (+teams, +invitations); env section points at existing `app.config.js` | MED |
| `infra/README.md` | SES vars are pre-filled in `env.example` (not "left blank"); MX host region is `var.aws_region`-derived | MED / LOW |
| `web/README.md` | refresh "not yet deployed as of" date | LOW |
| `docs/testing/e2e-test-plan-v2.0.md` | pdfkit `0.19.0`→`0.19.1`; `invitation-service.ts:168`→`:171`; added revision-history entries | LOW |

Memory docs (outside the repo) were fixed separately in the same pass: four broken wikilinks, a stale required-check name (`Analyze (javascript-typescript)` → `CodeQL`), and the backend test count (604/34 → ~838/50).

## Deploy note
`infra/README.md` falls under the deploy path filter (`infra/**`), so merging this triggers one harmless backend redeploy (same image, rebuilt). Optional follow-up: add a `!**/*.md` exclusion to the deploy filter so future docs edits under `backend/`/`infra/` don't deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)