### PR TITLE
fix(ci): don't trigger ECS deploy on docs-only (markdown) changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,15 +133,18 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
-          # Only these paths produce a new backend container image. Mobile-only
-          # changes (e.g. nightly mobile dep bumps) must NOT trigger an ECS
-          # deploy — that just adds noise and needless deploys.
+          # Only non-markdown changes under these paths produce a new backend
+          # container image. Mobile/web-only changes (e.g. nightly dep bumps) and
+          # docs-only edits (e.g. a README under backend/ or infra/) must NOT
+          # trigger an ECS deploy. `predicate-quantifier: every` makes a file
+          # count only if it matches the path brace AND is not a .md file
+          # (verified against picomatch, dorny's matcher — a plain `!**/*.md`
+          # under the default `some` quantifier would NOT exclude). See #184/#188.
+          predicate-quantifier: 'every'
           filters: |
             backend:
-              - 'backend/**'
-              - 'infra/**'
-              - 'docker/**'
-              - '.github/workflows/ci.yml'
+              - '{backend/**,infra/**,docker/**,.github/workflows/ci.yml}'
+              - '!**/*.md'
 
   build-and-deploy:
     name: Build & Deploy to ECS


### PR DESCRIPTION
## Why

The deploy path filter (added in #184) counted **any** change under `backend/**`, `infra/**`, `docker/**` — including markdown. So #188 (a docs PR touching `infra/README.md`) triggered a needless backend redeploy.

## What

Switch `dorny/paths-filter` to `predicate-quantifier: 'every'` with a brace-combined positive pattern + a `!**/*.md` negation:

```yaml
predicate-quantifier: 'every'
filters: |
  backend:
    - '{backend/**,infra/**,docker/**,.github/workflows/ci.yml}'
    - '!**/*.md'
```

A file now counts toward the deploy only if it's under a deploy path **AND** is not markdown.

## Verification

A plain `!**/*.md` under the default `some` quantifier does **not** exclude — it ORs in and would re-break the filter (it returns true even for web/mobile changes). I verified the `every` construction against **picomatch** (dorny's matcher) before landing:

| Changed file | deploys? |
|---|---|
| `infra/README.md`, `backend/README.md`, `docs/**.md` | ❌ no |
| `backend/src/index.ts`, `infra/ecs.tf`, `docker/Dockerfile`, `.github/workflows/ci.yml` | ✅ yes |
| `web/**`, `mobile/**` | ❌ no |

## Note
This PR changes `ci.yml` (a non-markdown deploy path), so merging it triggers one deploy — which doubles as the live confirmation that the new filter still deploys on real backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)