### PR TITLE
chore(deps): bump mobile patch deps (2026-06-15)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -17,7 +17,7 @@
         "@react-native-community/datetimepicker": "^8.6.0",
         "@sentry/react-native": "^8.13.0",
         "@tanstack/react-query": "^5.100.14",
-        "axios": "^1.17.0",
+        "axios": "^1.18.0",
         "babel-preset-expo": "^55.0.22",
         "expo": "^55.0.26",
         "expo-blur": "~55.0.14",
@@ -7653,9 +7653,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -16825,9 +16825,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -24,7 +24,7 @@
     "@react-native-community/datetimepicker": "^8.6.0",
     "@sentry/react-native": "^8.13.0",
     "@tanstack/react-query": "^5.100.14",
-    "axios": "^1.17.0",
+    "axios": "^1.18.0",
     "babel-preset-expo": "^55.0.22",
     "expo": "^55.0.26",
     "expo-blur": "~55.0.14",
@@ -86,7 +86,8 @@
     "tar": "^7.5.8",
     "@xmldom/xmldom": "^0.8.12",
     "follow-redirects": "^1.16.0",
-    "minimatch": "^5.1.8"
+    "minimatch": "^5.1.8",
+    "shell-quote": "^1.8.4"
   },
   "private": true
 }


### PR DESCRIPTION
Mobile daily-upgrade-scan auto-fix batch.

| Package | From | To | Notes |
| --- | --- | --- | --- |
| `axios` | 1.17.0 | 1.18.0 | lockfile patch (within caret) |
| `shell-quote` (override) | 1.8.3 → `^1.8.4` | **new override** | [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) (CRITICAL, CVSS 9.2) via `react-native` → `react-devtools-core` |

## Test results

- `npm run type-check` ✅
- `npm test` ✅ (401 tests, 39 suites)
- `npx expo export --platform ios` ✅
- `npm audit` — 0 critical / 0 high (was 1 critical / 0 high). Remaining 24 moderate + 1 low are all transitives rooted in deferred `eas-cli` / `expo` majors (same as prior runs).

Diff guard: only `mobile/package.json` + `mobile/package-lock.json` modified.

---
_Generated by the Daily Upgrade Scan routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_013EBpneLNzUjBjja7M1xdzo)_