### PR TITLE
chore(deps): bump mobile patch deps (2026-06-19)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -15,7 +15,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/datetimepicker": "^8.6.0",
-        "@sentry/react-native": "^8.14.0",
+        "@sentry/react-native": "^8.15.1",
         "@tanstack/react-query": "^5.101.0",
         "axios": "^1.17.0",
         "babel-preset-expo": "^55.0.22",
@@ -5628,27 +5628,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@react-native/community-cli-plugin/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@react-native/debugger-frontend": {
       "version": "0.83.6",
       "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.83.6.tgz",
@@ -5708,27 +5687,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@react-native/dev-middleware/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@react-native/gradle-plugin": {
@@ -5958,56 +5916,6 @@
         "join-component": "^1.1.0"
       }
     },
-    "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.57.0.tgz",
-      "integrity": "sha512-tXObp954rMTSYKlbftjVXHtNl4t/6ssks3jkqyzmKb+PDPWzabGQO7sWwqVuTjT8Kx/8A3FmriS1bGmqxiJy3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.57.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.57.0.tgz",
-      "integrity": "sha512-ZcF4QhkqGX3iiQSXB2N0N3Awp+j5iqnDRu6PA/qyLFrWqH5ZiiAAgu59OLD9E6XAdg6iFtLYw19MAMZVK8qNOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.57.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.57.0.tgz",
-      "integrity": "sha512-Wmnx/6ABynVH1iwuoNUqJNyjIUqsqoGML7qsyivBRKb5Wo2YQtPOQlQYfxfZSvWzGpcoSVdInkRjDssUQxQEQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "10.57.0",
-        "@sentry/core": "10.57.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.57.0.tgz",
-      "integrity": "sha512-zsfa4JcfV0AEc9YhNxNabd5lSZL2Av84saAyexGAqcHs+67m9Gd0cGStOzMb/nCl7UAtmdP0aI+G7a3rcxxN/A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/replay": "10.57.0",
-        "@sentry/core": "10.57.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@sentry-internal/tracing": {
       "version": "7.77.0",
       "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.77.0.tgz",
@@ -6047,25 +5955,37 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.57.0.tgz",
-      "integrity": "sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA==",
+      "version": "10.58.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.58.0.tgz",
+      "integrity": "sha512-Syf6h6HDwC15fk86+/0ql8ebwwJFw2wp+lvOX9GfLTJVOqrSILCrtLKNI+f4v/3w8mzImsv9ttJGGbUugLNvcA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.57.0",
-        "@sentry-internal/feedback": "10.57.0",
-        "@sentry-internal/replay": "10.57.0",
-        "@sentry-internal/replay-canvas": "10.57.0",
-        "@sentry/core": "10.57.0"
+        "@sentry/browser-utils": "10.58.0",
+        "@sentry/core": "10.58.0",
+        "@sentry/feedback": "10.58.0",
+        "@sentry/replay": "10.58.0",
+        "@sentry/replay-canvas": "10.58.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.58.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.58.0.tgz",
+      "integrity": "sha512-TzXrhZq3Llj6qPSv0ZVG5N5c7C6qNN/aRKJXhq2LombJrLwiQrWdgizp7zdHA0FGlZ7F5YpyRA2JIpkhvrFqYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.58.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/cli": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.5.0.tgz",
-      "integrity": "sha512-D3N3kULOnAClRkhHKqOAcOTtDnRe7hFacdHLlSsQXAZB11Qu6VAy8mGmM3654Lq/3LHl5h8CW590JGR9E0yahQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.5.1.tgz",
+      "integrity": "sha512-h710aEXT8At4lg7GbXDZkatDDq0uA5QKZmSiF/8Hy6jJZ/9dh6EBDZZpTYnDpNrwRvE8tqhnwEjTZDlHjOhPNQ==",
       "hasInstallScript": true,
       "license": "FSL-1.1-MIT",
       "dependencies": {
@@ -6081,20 +6001,20 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@sentry/cli-darwin": "3.5.0",
-        "@sentry/cli-linux-arm": "3.5.0",
-        "@sentry/cli-linux-arm64": "3.5.0",
-        "@sentry/cli-linux-i686": "3.5.0",
-        "@sentry/cli-linux-x64": "3.5.0",
-        "@sentry/cli-win32-arm64": "3.5.0",
-        "@sentry/cli-win32-i686": "3.5.0",
-        "@sentry/cli-win32-x64": "3.5.0"
+        "@sentry/cli-darwin": "3.5.1",
+        "@sentry/cli-linux-arm": "3.5.1",
+        "@sentry/cli-linux-arm64": "3.5.1",
+        "@sentry/cli-linux-i686": "3.5.1",
+        "@sentry/cli-linux-x64": "3.5.1",
+        "@sentry/cli-win32-arm64": "3.5.1",
+        "@sentry/cli-win32-i686": "3.5.1",
+        "@sentry/cli-win32-x64": "3.5.1"
       }
     },
     "node_modules/@sentry/cli-darwin": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.5.0.tgz",
-      "integrity": "sha512-Q7WIq+SNMh/7gddovgcHUBlgzsH2jASdkxinwxoDZVNcF96gqr35QllRHkxZTt1+nLM3JytL2A+Mh9JdvMWzsA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.5.1.tgz",
+      "integrity": "sha512-GxHAtZaXRA650egcepQXU0pR0dZ8ZNvQS8eq3wBxhCK8os5VQpLyBABIaN6AdrE/b8M7UvqGjsuVm0giI1GZ7w==",
       "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
@@ -6105,9 +6025,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.5.0.tgz",
-      "integrity": "sha512-d4U64gQikZiqr63XL3suWhd28e0NQg63GX+JumRiDYCDCAF3gmdUS6BRR43lyoZm2wqhHRQSms2bMArAPTDH/w==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.5.1.tgz",
+      "integrity": "sha512-JOfgXCDZKbxQpw8Z4Kbkt8Hl+ASW5pYVUYw8Hc2msPN3HtfTmsc1z0y6jq3TCUWDWbWpWbI1zfXa0v02vQf3gw==",
       "cpu": [
         "arm"
       ],
@@ -6123,9 +6043,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm64": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.5.0.tgz",
-      "integrity": "sha512-nWlWo0qw1OqcOFR6GgcJ3KT+bMOlE3BFBtbMCxyURb4dTcT+NPy1Oe9Kk+JyWgRk1xm4CTaPXJNd2JD5V36FQA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.5.1.tgz",
+      "integrity": "sha512-Qa0NLXG/FSYWGhKjdm2mxp/GgpluFFkj/J+CpmVzwvezNC/Uy1omquv7J+VficqskNYuptjsoB4dNIPPcXpbxg==",
       "cpu": [
         "arm64"
       ],
@@ -6141,9 +6061,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-i686": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.5.0.tgz",
-      "integrity": "sha512-HE8zFNvg/YWudGp+pBeJSNgF/siyarnlBkWbRxz6WApsFq7uvajXPk7EqwJ0onKnzPS14OPlTtTejA3iSUuCNg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.5.1.tgz",
+      "integrity": "sha512-/Bqcl8EyS6T8RIjBeeMYUPgjMJ8kb4plF0w3QOG6TY+bUEqHEnZyfzKJWZY/OqhmrSgj+ZYynaSHIIR6dWluMA==",
       "cpu": [
         "x86",
         "ia32"
@@ -6160,9 +6080,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-x64": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.5.0.tgz",
-      "integrity": "sha512-uU6h/b3SIoWysn0U6PoyUx/R5z9kU9+VcuvydjlqkZGDbbcRIxqp0T/wgB/jhXeFaSSPSFlmmkQCVYi8PXCrSw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.5.1.tgz",
+      "integrity": "sha512-iUJT2GI/soc0myi1sSnXdu71oBkUER3fBeXn10bcEZX+UK9GomsqL40OLlygDipZZ6FqhODORqLeTxHdHbRuOw==",
       "cpu": [
         "x64"
       ],
@@ -6178,9 +6098,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-arm64": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.5.0.tgz",
-      "integrity": "sha512-P13w9Vc/ur6rnwtiBe4wzu4M81ODhdOGc8iWpkN51gzjldjz9FF4F2UEdS9UUYBxesWJU+UF62ZVQ4H73rhS4g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.5.1.tgz",
+      "integrity": "sha512-Hs4jHOsTKrrI2W8c4wEIvQzSuHqvrjsDHT7iwujHjp4oeAOnYjBUm+/BgDH2Eg1/jL5ilEnJbpnAn2AE2KQUXQ==",
       "cpu": [
         "arm64"
       ],
@@ -6194,9 +6114,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-i686": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.5.0.tgz",
-      "integrity": "sha512-LZIEsJ5zMd0HAYlnG7G7OM6/AOvFaWkuBPdePZqYvtMLOUsfY7zeW8ubyZ9uCOWsj5Xc7UiDF4v0gZ45Strlkg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.5.1.tgz",
+      "integrity": "sha512-Op+9MYAg0RbVWOQ9/NtFunWcknS8MlqhEa03ENFUrRDQE0m+iHioknGOagKrNXYXj1UbGEf0G9UzIMcRwB/UCQ==",
       "cpu": [
         "x86",
         "ia32"
@@ -6211,9 +6131,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-x64": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.5.0.tgz",
-      "integrity": "sha512-Dgkn60xoF7csXcKk+gRlmOA7s//7w0R3QlaXCo5RbX/c5VTbcV74r6ON7A+SKTFO9i4fEGblLlzQ0MLqrIo2sw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.5.1.tgz",
+      "integrity": "sha512-Vf+CtFPkuGzjddD6dJoAVKszw5QB7P1ffc++yAbU54ditqJdgswo45oyTFOiQFO2isCmhgICzimqe8SkU+p2Mw==",
       "cpu": [
         "x64"
       ],
@@ -6227,21 +6147,21 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.57.0.tgz",
-      "integrity": "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==",
+      "version": "10.58.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.58.0.tgz",
+      "integrity": "sha512-bkIbh2c6dzwhrWn/FGWu7j8hf6TAat2XxpkGM91LiN09fLYUXIMwcohVsXqze5l2cq35TnvqmSROAbRNr27GVw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/expo-upload-sourcemaps": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/expo-upload-sourcemaps/-/expo-upload-sourcemaps-8.14.0.tgz",
-      "integrity": "sha512-caPp11nVIAHtCTaM2kTqf3wG5aAui09EbeqoBEA9//NnRkuOVuRqapfX+ABTFlnnimbBSvn3MKrQt6HTMp/ELQ==",
+      "version": "8.15.1",
+      "resolved": "https://registry.npmjs.org/@sentry/expo-upload-sourcemaps/-/expo-upload-sourcemaps-8.15.1.tgz",
+      "integrity": "sha512-aMHsbBRdrtTaWDMDA13sqY17QPG3F0mKHsts5biuVIZHVE3BMzUT/ZF/3KAd4JWttAPJFQ9yJP9Caw7zN/mW6w==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/cli": "3.5.0"
+        "@sentry/cli": "3.5.1"
       },
       "bin": {
         "expo-upload-sourcemaps": "cli.js"
@@ -6260,6 +6180,18 @@
         "dotenv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.58.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.58.0.tgz",
+      "integrity": "sha512-VmIlR/0O0GXITbvgjPkQqd6yM0JDEk52WXv6Rs1kTdaIDU5h3Y64VDVN4MAbYVRHqSz7F1arjRRk2FkaKC7ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.58.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
@@ -6294,13 +6226,13 @@
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.57.0.tgz",
-      "integrity": "sha512-6QThwQ4XWQ2rwKZEVQ9P9WKl7JlowC7S5LpAvmMdrwlfJBpLDFOsM7tycnIvbXTXf0ZOOuLFPa4L4YYbdyNGmA==",
+      "version": "10.58.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.58.0.tgz",
+      "integrity": "sha512-3FLRtnXrue30UZALrQ9wQZeuvVmZl/pTCA+RyPlaZ5GxcYTapN9CVbm1IvbQpK4w1bt80+JxaKM4HikvII6KpA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.57.0",
-        "@sentry/core": "10.57.0"
+        "@sentry/browser": "10.58.0",
+        "@sentry/core": "10.58.0"
       },
       "engines": {
         "node": ">=18"
@@ -6310,17 +6242,17 @@
       }
     },
     "node_modules/@sentry/react-native": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.14.0.tgz",
-      "integrity": "sha512-2OF5M1Easgo25qX5360I/zb/P8IPhu6YXTgvCQCA6AYHxZvLf/9w/Rzaa+BYl6wBnnUvserjtua1xXdSrQhQXA==",
+      "version": "8.15.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.15.1.tgz",
+      "integrity": "sha512-kjEHsiv94zrID7KAdtmlAsHHBHi5O7Eg+xs9Ko/ylM+KEpID9w24MjqL75dJ94r3cynV6dxBLcc1hgBy61ZEAQ==",
       "license": "MIT",
       "dependencies": {
         "@sentry/babel-plugin-component-annotate": "5.3.0",
-        "@sentry/browser": "10.57.0",
-        "@sentry/cli": "3.5.0",
-        "@sentry/core": "10.57.0",
-        "@sentry/expo-upload-sourcemaps": "8.14.0",
-        "@sentry/react": "10.57.0"
+        "@sentry/browser": "10.58.0",
+        "@sentry/cli": "3.5.1",
+        "@sentry/core": "10.58.0",
+        "@sentry/expo-upload-sourcemaps": "8.15.1",
+        "@sentry/react": "10.58.0"
       },
       "bin": {
         "sentry-eas-build-on-complete": "scripts/eas-build-hook.js",
@@ -6337,6 +6269,32 @@
         "expo": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.58.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.58.0.tgz",
+      "integrity": "sha512-EVasQNUenpwJksK9DI1TQ78YytpjLAhxn0UTiHqA3sU/s1fHK5XZdZJPr/9uEGedRoInIP0UIWmbOtOEX8HHDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.58.0",
+        "@sentry/core": "10.58.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.58.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.58.0.tgz",
+      "integrity": "sha512-ufFmaJ968DXGe6u9W/UqNVjCCTtAqT2bNtSu1jHAjIFFpWIuM80lcR33grK6SuGnFxceu5iJFaIW6JRyfbM0Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.58.0",
+        "@sentry/replay": "10.58.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/types": {
@@ -8710,27 +8668,6 @@
         "xmlhttprequest-ssl": "~2.1.1"
       }
     },
-    "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -10354,16 +10291,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -13750,27 +13687,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/metro/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -15027,27 +14943,6 @@
         "ws": "^7"
       }
     },
-    "node_modules/react-devtools-core/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-dom": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
@@ -15546,27 +15441,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/react-native/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-refresh": {
@@ -17131,9 +17005,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -22,7 +22,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "^8.6.0",
-    "@sentry/react-native": "^8.14.0",
+    "@sentry/react-native": "^8.15.1",
     "@tanstack/react-query": "^5.101.0",
     "axios": "^1.17.0",
     "babel-preset-expo": "^55.0.22",
@@ -86,7 +86,11 @@
     "tar": "^7.5.8",
     "@xmldom/xmldom": "^0.8.12",
     "follow-redirects": "^1.16.0",
-    "minimatch": "^5.1.8"
+    "minimatch": "^5.1.8",
+    "form-data": "^4.0.6",
+    "shell-quote": "^1.8.4",
+    "undici": "^6.27.0",
+    "ws": "^8.21.0"
   },
   "private": true
 }


### PR DESCRIPTION
Mobile daily-upgrade-scan auto-fix batch.

## New overrides (HIGH/CRITICAL CVEs)

| Package | Override | Advisory |
| --- | --- | --- |
| `form-data` | `^4.0.6` | [GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx) (HIGH, CVSS 7.5) — CRLF injection via unescaped multipart field names |
| `shell-quote` | `^1.8.4` | [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) (CRITICAL, CVSS 9.2) — `quote()` does not escape newlines in object `.op` values; reached via `react-native` → `react-devtools-core` |
| `undici` | `^6.27.0` | [GHSA-p88m-4jfj-68fv](https://github.com/advisories/GHSA-p88m-4jfj-68fv) — HTTP header injection via `Set-Cookie` percent-decoding |
| `ws` | `^8.21.0` | [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) (HIGH, CVSS 7.5) — memory exhaustion DoS. Also resolves transitive HIGH `engine.io-client` |

## Lockfile patches (within existing caret)

| Package | From | To |
| --- | --- | --- |
| `@sentry/react-native` | 8.14.0 | 8.15.1 |

Skipped because it already has an open PR:
- `axios` 1.17.0 → 1.18.0 — covered by #191

## Test results

- `npm run type-check` ✅
- `npm test` ✅ (401 tests, 39 suites)
- `npx expo export --platform ios` ✅
- `npm audit` — **4 high + 0 critical → 0 high + 0 critical** (resolved: `engine.io-client`, `form-data`, `undici`, `ws`, and the `shell-quote` critical that was unmasked once `undici`/`ws` were pinned)

Diff guard: only `mobile/package.json` + `mobile/package-lock.json` modified.

---
_Generated by the Daily Upgrade Scan routine. Supersedes the stale #193 (open since 2026-06-15, conflicts with main)._


---
_Generated by [Claude Code](https://claude.ai/code/session_017pPFonVYk7FuiR5T7hsaWu)_