### PR TITLE
docs: WorkOS E2E test-account scheme + role-promotion script

### DIFF
--- a/backend/scripts/promote-test-users.ts
+++ b/backend/scripts/promote-test-users.ts
@@ -1,0 +1,129 @@
+/**
+ * Promote E2E test users (the `deasystephen+<persona>@gmail.com` aliases) to the
+ * roles the v2.0 E2E test plan needs.
+ *
+ * Why this script exists:
+ *  - WorkOS signup always creates users as PLAYER (ADMIN only via ADMIN_EMAIL), see
+ *    src/services/workos-service.ts. Re-login never overwrites `role`, so DB changes stick.
+ *  - Creating a team requires `User.role === 'COACH'` (src/services/team-service.ts), so the
+ *    head-coach alias must be bumped BEFORE it can create a team.
+ *  - The staff-assignment and guardian endpoints are NOT implemented (only Zod schemas are
+ *    stubbed in src/api/teams/schemas.ts), so ASSISTANT_COACH / TEAM_MANAGER / PARENT can only
+ *    be set by writing to the DB — which is what this script does.
+ *
+ * Run order:
+ *  1. All aliases sign in once via WorkOS (creates the User rows).
+ *  2. Run with `--phase=pre`  -> bumps headcoach -> COACH and parent -> PARENT.
+ *  3. ADMIN creates the League + Season in-app (test C.1/C.2).
+ *  4. Head coach creates "Test Team" in-app (test D.1) -> auto Head Coach + default team roles.
+ *  5. The +player alias joins the team (invite-accept E.1->E.5, or a TeamMember insert).
+ *  6. Run with `--phase=post` -> inserts TeamStaff (asst coach + manager) and the Guardian link.
+ *  Run with no flag (or `--phase=all`) to attempt both phases in one go.
+ *
+ * Usage (point DATABASE_URL at the PRODUCTION RDS instance you are testing against):
+ *   cd backend
+ *   DATABASE_URL="<prod-url>" npx tsx scripts/promote-test-users.ts --phase=pre
+ *   DATABASE_URL="<prod-url>" npx tsx scripts/promote-test-users.ts --phase=post
+ *
+ * Safe to re-run: role updates are idempotent and inserts use skipDuplicates.
+ */
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// ---- Config: tweak here if your alias scheme or team name differs ----------
+const BASE_LOCALPART = 'deasystephen';
+const BASE_DOMAIN = 'gmail.com';
+const TEAM_NAME = 'Test Team';
+const aliasEmail = (tag: string) => `${BASE_LOCALPART}+${tag}@${BASE_DOMAIN}`;
+
+const phaseArg = process.argv.find((a) => a.startsWith('--phase='));
+const phase = (phaseArg?.split('=')[1] ?? 'all') as 'pre' | 'post' | 'all';
+
+async function getUserIdByAlias(tag: string): Promise<string> {
+  const user = await prisma.user.findFirst({ where: { email: aliasEmail(tag) } });
+  if (!user) {
+    throw new Error(
+      `User ${aliasEmail(tag)} not found — has this alias signed in via WorkOS yet?`,
+    );
+  }
+  return user.id;
+}
+
+async function runPre() {
+  console.log('Phase: pre — system-role bumps');
+
+  const headCoach = await prisma.user.update({
+    where: { email: aliasEmail('headcoach') },
+    data: { role: 'COACH' },
+  });
+  console.log(`  ✓ ${headCoach.email} -> COACH (can now create a team)`);
+
+  const parent = await prisma.user.update({
+    where: { email: aliasEmail('parent') },
+    data: { role: 'PARENT' },
+  });
+  console.log(`  ✓ ${parent.email} -> PARENT`);
+}
+
+async function runPost() {
+  console.log(`Phase: post — team staff + guardian (team: "${TEAM_NAME}")`);
+
+  const team = await prisma.team.findFirst({ where: { name: TEAM_NAME } });
+  if (!team) {
+    throw new Error(
+      `Team "${TEAM_NAME}" not found — the head coach must create it in-app first (test D.1).`,
+    );
+  }
+
+  const roleByName = async (name: string) => {
+    const role = await prisma.teamRole.findFirst({ where: { teamId: team.id, name } });
+    if (!role) {
+      throw new Error(
+        `TeamRole "${name}" not found on team ${team.id}. Default roles are created on team ` +
+          `creation — confirm the team was made via the app, not inserted manually.`,
+      );
+    }
+    return role;
+  };
+
+  const assistantRole = await roleByName('Assistant Coach');
+  const managerRole = await roleByName('Team Manager');
+
+  const staff = await prisma.teamStaff.createMany({
+    skipDuplicates: true,
+    data: [
+      { teamId: team.id, userId: await getUserIdByAlias('asstcoach'), roleId: assistantRole.id },
+      { teamId: team.id, userId: await getUserIdByAlias('manager'), roleId: managerRole.id },
+    ],
+  });
+  console.log(`  ✓ TeamStaff inserted (asst coach + manager): ${staff.count} new row(s)`);
+
+  // Parent must be a guardian of the player who is actually on the team, so the
+  // parent's read access (test Q.7) resolves through Guardian -> child -> TeamMember.
+  const guardian = await prisma.guardian.createMany({
+    skipDuplicates: true,
+    data: [
+      {
+        parentId: await getUserIdByAlias('parent'),
+        childId: await getUserIdByAlias('player'),
+        relationship: 'MOTHER', // MOTHER | FATHER | GUARDIAN | OTHER
+        isPrimary: true,
+      },
+    ],
+  });
+  console.log(`  ✓ Guardian link (parent -> player): ${guardian.count} new row(s)`);
+}
+
+async function main() {
+  if (phase === 'pre' || phase === 'all') await runPre();
+  if (phase === 'post' || phase === 'all') await runPost();
+  console.log('Done.');
+}
+
+main()
+  .catch((err) => {
+    console.error('Promotion failed:', err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/docs/testing/workos-test-accounts.md
+++ b/docs/testing/workos-test-accounts.md
@@ -1,0 +1,96 @@
+# WorkOS test accounts & role promotion (E2E v2.0)
+
+Companion to [`e2e-test-plan-v2.0.md`](./e2e-test-plan-v2.0.md). Use this when **dev-login
+is not available** (production / TestFlight build), so every persona must be a real WorkOS
+sign-in. It covers the account scheme, SES sandbox verification, and how to promote each
+account to the role the plan needs.
+
+## Personas & alias scheme
+
+All personas use `+alias` addresses on the verified inbox so they (a) sign in as distinct
+WorkOS identities, (b) all deliver to one Gmail inbox, and (c) never collide with the ADMIN
+auto-assignment (which is an exact match on `ADMIN_EMAIL`, see `workos-service.ts`).
+
+| Persona | Sign-in email | System `User.role` | Team linkage | Receives email? |
+|---|---|---|---|---|
+| ADMIN | `deasystephen@gmail.com` | `ADMIN` (auto) | — | already verified |
+| Head Coach | `deasystephen+headcoach@gmail.com` | `COACH` (bump in DB) | `TeamStaff` → Head Coach | announcements (J) |
+| On-team Player | `deasystephen+player@gmail.com` | `PLAYER` (default) | `TeamMember` | RSVP (I), announcements (J), push (N) |
+| Assistant Coach | `deasystephen+asstcoach@gmail.com` | `PLAYER` (default) | `TeamStaff` → Assistant Coach | no |
+| Team Manager | `deasystephen+manager@gmail.com` | `PLAYER` (default) | `TeamStaff` → Team Manager | no |
+| Outsider Player | `deasystephen+outsider@gmail.com` | `PLAYER` (default) | none (control) | no |
+| Parent | `deasystephen+parent@gmail.com` | `PARENT` (bump in DB) | `Guardian` → on-team player | announcements (J) |
+
+> The 3 "no email" boundary personas (asst coach, manager, outsider) don't need SES verification.
+
+## Step 1 — SES sandbox verification (email-receiving aliases only)
+
+SES sandbox verifies **exact** addresses; verifying the base inbox does **not** cover
+`+aliases`. Verify each receiver, then click the confirmation link (it lands in your inbox):
+
+```bash
+for alias in headcoach player parent invitee2; do
+  aws sesv2 create-email-identity \
+    --email-identity "deasystephen+${alias}@gmail.com" --region us-east-1
+done
+```
+
+Confirm status is `SUCCESS` before testing:
+
+```bash
+for alias in headcoach player parent invitee2; do
+  printf '%-40s ' "deasystephen+${alias}@gmail.com"
+  aws sesv2 get-email-identity --email-identity "deasystephen+${alias}@gmail.com" \
+    --region us-east-1 --query 'VerifiedForSendingStatus' --output text
+done
+```
+
+(`+invitee2` is the second invitee used in test E.6.)
+
+## Step 2 — Role promotion sequence
+
+Only **ADMIN** (auto via `ADMIN_EMAIL`) and **Head Coach** (after a role bump + creating a team
+in-app) can be set through the app. Assistant Coach, Team Manager, and Parent have **no API
+endpoints** (the staff/guardian routes are unimplemented — only Zod schemas are stubbed in
+`backend/src/api/teams/schemas.ts`), so they require direct DB writes. The
+[`promote-test-users.ts`](../../backend/scripts/promote-test-users.ts) script does these writes.
+
+Order matters:
+
+1. **All 6 aliases sign in once** via WorkOS (creates the `User` rows; everyone starts `PLAYER`).
+2. **`--phase=pre`** — bump `+headcoach` → `COACH` and `+parent` → `PARENT`.
+   (Head coach *must* be `COACH` before step 4: `createTeam` 403s otherwise — `team-service.ts`.)
+3. **ADMIN** creates the League + Season in-app (tests C.1–C.2; admin-only).
+4. **Head coach** creates `Test Team` linked to that season (test D.1) → auto-assigned Head Coach
+   and the team's default roles ("Head Coach", "Assistant Coach", "Team Manager") now exist.
+5. **`+player`** joins the team — easiest via the invite-accept flow the plan already tests
+   (E.1 → E.5), which creates the `TeamMember`. (A manual `TeamMember` insert also works.)
+6. **`--phase=post`** — insert `TeamStaff` rows for `+asstcoach` and `+manager`, and the
+   `Guardian` link `+parent` → `+player`.
+
+### Running the script
+
+⚠️ You are testing against the **production** backend (ECS / RDS). Point `DATABASE_URL` at the
+production database (from `bball-tracker-production/database-url` in Secrets Manager) and
+double-check before writing. The script is idempotent (role updates + `skipDuplicates` inserts).
+
+```bash
+cd backend
+DATABASE_URL="<prod-url>" npx tsx scripts/promote-test-users.ts --phase=pre   # before team creation
+# ... admin creates league+season, head coach creates "Test Team", player accepts invite ...
+DATABASE_URL="<prod-url>" npx tsx scripts/promote-test-users.ts --phase=post  # after team + player
+```
+
+Edit the constants at the top of the script if your alias scheme or team name differs.
+
+## Gotchas
+
+- **Re-login never overwrites `User.role`** — `syncUser` only sets `role` on first create, so DB
+  promotions persist across logins (`workos-service.ts`).
+- **Head coach needs `COACH` before creating a team**, or test D.1 returns 403.
+- **Parent read access (test Q.7 → 200)** resolves through `Guardian → child → TeamMember`, so the
+  guardian's `childId` must be the `+player` who is actually on the team.
+- **Permission flags come from the team role**, not the system role: Assistant Coach has full perms
+  incl. `canManageRoster` (so Q.4 roster ops should succeed); Team Manager has only
+  `canTrackStats` / `canViewStats` / `canShareStats`, no `canManageRoster` (so Q.6 depends on
+  `canTrackStats=true`). See `backend/src/utils/permissions.ts`.

--- a/docs/testing/workos-test-accounts.md
+++ b/docs/testing/workos-test-accounts.md
@@ -83,6 +83,22 @@ DATABASE_URL="<prod-url>" npx tsx scripts/promote-test-users.ts --phase=post  # 
 
 Edit the constants at the top of the script if your alias scheme or team name differs.
 
+## Heads-up: incoming v1.2.0 entitlement gating (PR #202, `develop` → `main`)
+
+The v1.2.0 release adds usage metering + entitlement gating. It does **not** change the role
+model or add the missing staff/guardian routes, so the promotion sequence above is unaffected.
+Two things to know once it lands in production:
+
+- **Team creation** is gated by `requireTeamCreateLimit()` — FREE-tier users get HTTP 402 once
+  they are staff on `FREE_TEAM_LIMIT` (3) teams. The plan only creates one `Test Team`, so the
+  head coach stays under the cap; **no PREMIUM tier needed for D.1**.
+- **Stats export** (test plan §M) now requires `requireEntitlement(STATS_EXPORT)`, which is
+  **PREMIUM-only**. A FREE-tier coach gets 402, so run §M as a PREMIUM user or as ADMIN.
+- **System ADMIN bypasses all entitlement and usage checks** (`req.user.role === 'ADMIN'`), which
+  is the simplest way to exercise the export paths.
+
+See `backend/src/services/entitlements/` and `backend/src/api/middleware/entitlements.ts`.
+
 ## Gotchas
 
 - **Re-login never overwrites `User.role`** — `syncUser` only sets `role` on first create, so DB


### PR DESCRIPTION
## Summary

Provisioning guide + automation for the WorkOS personas the v2.0 E2E test plan needs **when dev-login is unavailable** (production / TestFlight build), so every persona must be a real WorkOS sign-in.

Adds:
- **`docs/testing/workos-test-accounts.md`** — `+alias` account scheme, SES sandbox verification commands, the ordered role-promotion sequence, and the role/permission gotchas. Sits next to `e2e-test-plan-v2.0.md`.
- **`backend/scripts/promote-test-users.ts`** — idempotent `tsx` script that performs the role assignments which have **no API endpoint**.

## Why a script is needed

Investigating the role model surfaced that several roles can't be set through the app:
- WorkOS signup always creates users as `PLAYER` (`ADMIN` only via `ADMIN_EMAIL`); re-login never overwrites `role`, so DB changes stick.
- Creating a team requires `User.role === 'COACH'`, so the head-coach alias must be bumped **before** it can create a team.
- The staff-assignment and guardian endpoints are **unimplemented** (only Zod schemas are stubbed in `backend/src/api/teams/schemas.ts`), so `ASSISTANT_COACH` / `TEAM_MANAGER` / `PARENT` can only be set via DB writes — which the script does.

## Script phases

- `--phase=pre` — bump `+headcoach` → `COACH`, `+parent` → `PARENT` (run before team creation).
- `--phase=post` — insert `TeamStaff` (assistant coach + team manager) and the `Guardian` link `+parent` → `+player` (run after the head coach has created `Test Team` and the player has joined).

Safe to re-run (role updates + `createMany` with `skipDuplicates`). Points at the production RDS you're testing against.

## Compatibility with incoming v1.2.0 (#202)

Checked against `develop`: the role model, `utils/permissions.ts`, and `workos-service.ts` are unchanged, and no staff/guardian routes were added — so the promotion sequence is unaffected. The doc includes a heads-up that v1.2.0's entitlement gating adds a team-create limit (non-issue at one team) and makes stats export PREMIUM-only (test as ADMIN, which bypasses all gates).

## Notes

- Docs + a `tsx`-run script only — no changes to `src/`. `scripts/` is outside the tsconfig `include` (same as existing `prisma/*.ts` scripts), so it isn't in CI type-check/lint. Couldn't run `tsc`/`prisma generate` in the authoring container (deps not installed); field/enum names were verified against `schema.prisma`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sh96Np2m7rVogmxSJHj2LX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sh96Np2m7rVogmxSJHj2LX)_