### PR TITLE
docs: v1.2.0 gating accuracy fix + docs-hygiene Stop hook

### DIFF
--- a/.claude/hooks/check-docs-updated.sh
+++ b/.claude/hooks/check-docs-updated.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Stop hook: remind to update docs when code changed but docs did not.
+#
+# Non-blocking by design — it only surfaces a reminder; it never prevents the
+# session from stopping and never edits anything. Fires on the Stop event,
+# inspects the working tree, and warns when source files changed without a
+# corresponding update to docs/ or CLAUDE.md.
+set -uo pipefail
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -z "$root" ] && exit 0
+cd "$root" || exit 0
+
+# Tracked (staged + unstaged) changes vs HEAD, plus untracked files.
+changed="$({ git diff --name-only HEAD 2>/dev/null || true; \
+             git ls-files --others --exclude-standard 2>/dev/null || true; } | sort -u)"
+[ -z "$changed" ] && exit 0
+
+# If any documentation changed, assume docs were considered — stay quiet.
+docs_changed="$(printf '%s\n' "$changed" | grep -E '(^|/)CLAUDE\.md$|^docs/|\.md$' || true)"
+[ -n "$docs_changed" ] && exit 0
+
+# Only nudge when actual source files changed (backend/mobile/web code).
+code_changed="$(printf '%s\n' "$changed" | grep -E '^(backend|mobile|web)/.*\.(ts|tsx|js|jsx|mjs|cjs|prisma)$' || true)"
+[ -z "$code_changed" ] && exit 0
+
+count="$(printf '%s\n' "$code_changed" | sed '/^$/d' | wc -l | tr -d ' ')"
+msg="Docs check: ${count} code file(s) changed in the working tree but no docs/ or CLAUDE.md updates. Verify whether documentation needs updating before wrapping up."
+
+# Non-blocking reminder: shown to the user and injected into model context.
+printf '{"systemMessage": "%s", "hookSpecificOutput": {"hookEventName": "Stop", "additionalContext": "%s"}}' "$msg" "$msg"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-docs-updated.sh",
+            "timeout": 10,
+            "statusMessage": "Checking docs are up to date with code changes..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ docker-compose.override.yml
 Thumbs.db
 
 .gstack/
+
+# Claude Code personal overrides (committed config lives in .claude/settings.json)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,12 @@ The fix: Add API integration tests AND schema validation tests for every endpoin
 
 - **Before starting new work, ensure prior work is committed.** If there are uncommitted changes from a previous feature, test them (`npm test`, `npx tsc --noEmit`), commit them on an appropriate branch, and verify a clean `git status` before beginning a new task. Mixing unrelated features in the same uncommitted diff makes testing and rollback difficult.
 
+## Documentation Hygiene
+
+- **Keep docs in sync with code.** When a change alters behavior, APIs, schema, env vars, commands, architecture, or operational steps, update the affected documentation in the **same change** — `CLAUDE.md`, `docs/` (architecture, runbooks, testing plans, automation), and any relevant `README`.
+- **Forward-references go stale.** When you reference an unmerged PR or "incoming" work in docs, revisit it once that work lands and reword to past tense (e.g. "merged in #202", not "incoming"). Distinguish "merged to `main`" from "deployed to production" where it matters.
+- A committed **Stop hook** (`.claude/hooks/check-docs-updated.sh`) prints a reminder when code files changed in the working tree without any `docs/` or `CLAUDE.md` update. It is advisory only — treat it as a prompt to confirm docs are current, not a blocker.
+
 ## Git Workflow
 
 - Main branches: `main` and `develop`

--- a/docs/testing/workos-test-accounts.md
+++ b/docs/testing/workos-test-accounts.md
@@ -90,11 +90,13 @@ DATABASE_URL="<prod-url>" npx tsx scripts/promote-test-users.ts --phase=post  # 
 
 Edit the constants at the top of the script if your alias scheme or team name differs.
 
-## Heads-up: incoming v1.2.0 entitlement gating (PR #202, `develop` → `main`)
+## Heads-up: v1.2.0 entitlement gating (merged in #202)
 
-The v1.2.0 release adds usage metering + entitlement gating. It does **not** change the role
-model or add the missing staff/guardian routes, so the promotion sequence above is unaffected.
-Two things to know once it lands in production:
+The v1.2.0 release (#202, now on `main`) adds usage metering + entitlement gating. It does **not**
+change the role model or add the missing staff/guardian routes, so the promotion sequence above is
+unaffected. Being on `main` is not the same as being deployed — confirm the production ECS task you
+are testing against is running a v1.2.0+ revision before assuming these gates are live. Once they
+are, three things to know:
 
 - **Team creation** is gated by `requireTeamCreateLimit()` — FREE-tier users get HTTP 402 once
   they are staff on `FREE_TEAM_LIMIT` (3) teams. The plan only creates one `Test Team`, so the


### PR DESCRIPTION
## Summary

Two related docs/process changes:

### 1. Accuracy fix — `workos-test-accounts.md`
Now that #202 (v1.2.0 — usage metering / entitlement gating) has merged to `main`, the guide's entitlement-gating section was stale (written as *incoming, develop → main*).
- Reframe from "incoming" to **merged on `main` (#202)**.
- Add the caveat that being on `main` ≠ deployed to the production ECS task under test (the E2E plan targets rev 133; v1.2.0 is a later revision).
- Fix the "Two/three things" count to match the three bullets.

### 2. Docs-hygiene automation (team-wide)
Keep docs in sync with code going forward:
- **`.claude/hooks/check-docs-updated.sh`** — non-blocking **Stop hook** that reminds when source files changed in the working tree without a `docs/` or `CLAUDE.md` update. Advisory only; never blocks or edits. Pipe-tested across all three paths (no-code-change → silent, code-only → reminder, code+docs → suppressed).
- **`.claude/settings.json`** — registers the Stop hook (committed, so it applies for all teammates using Claude Code).
- **`CLAUDE.md`** — new "Documentation Hygiene" section (update docs in the same change; reword stale forward-references once work lands).
- **`.gitignore`** — ignore `.claude/settings.local.json` (personal overrides).

## Notes

- Docs + shell/JSON config only; no `src/` changes.
- The hook won't be active in a session that started before `.claude/` existed — teammates open `/hooks` once (or restart) to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sh96Np2m7rVogmxSJHj2LX