### PR TITLE
feat: support ADMIN_EMAILS allowlist for admin role on sign-up

### DIFF
--- a/backend/src/services/workos-service.ts
+++ b/backend/src/services/workos-service.ts
@@ -5,6 +5,7 @@
 import { workos, WORKOS_CLIENT_ID, WORKOS_REDIRECT_URI } from '../utils/workos-client';
 import prisma from '../models';
 import { logger } from '../utils/logger';
+import { isAdminEmail } from '../utils/admin-emails';
 
 export class WorkOSService {
   /**
@@ -129,7 +130,7 @@ export class WorkOSService {
         workosUserId: workosUser.id,
         email: workosUser.email,
         name: fullName,
-        role: process.env.ADMIN_EMAIL === workosUser.email ? 'ADMIN' : 'PLAYER',
+        role: isAdminEmail(workosUser.email) ? 'ADMIN' : 'PLAYER',
         emailVerified: workosUser.emailVerified || false,
         profilePictureUrl: workosUser.profilePictureUrl || null,
       },

--- a/backend/src/utils/admin-emails.ts
+++ b/backend/src/utils/admin-emails.ts
@@ -1,0 +1,30 @@
+/**
+ * Admin email allowlist.
+ *
+ * A user is granted the ADMIN role at first sign-up when their email is on the
+ * allowlist. The allowlist is read from two env vars (merged), case-insensitive:
+ *   - ADMIN_EMAILS: comma-separated list (preferred — the "admin group")
+ *   - ADMIN_EMAIL:  single email (legacy; still honored for backward compatibility)
+ *
+ * Note: this governs role assignment at account creation only. Changing the
+ * allowlist does NOT retroactively promote or demote existing accounts —
+ * `syncUser` never rewrites the role of an existing user.
+ */
+
+/** Parsed, de-duplicated, lower-cased admin emails from the environment. */
+export function getAdminEmails(): string[] {
+  const raw = `${process.env.ADMIN_EMAILS ?? ''},${process.env.ADMIN_EMAIL ?? ''}`;
+  const normalized = raw
+    .split(',')
+    .map((email) => email.trim().toLowerCase())
+    .filter((email) => email.length > 0);
+  return [...new Set(normalized)];
+}
+
+/** True when `email` is on the admin allowlist (case-insensitive). */
+export function isAdminEmail(email: string | null | undefined): boolean {
+  if (!email) {
+    return false;
+  }
+  return getAdminEmails().includes(email.trim().toLowerCase());
+}

--- a/backend/tests/utils/admin-emails.test.ts
+++ b/backend/tests/utils/admin-emails.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the admin email allowlist (ADMIN_EMAILS + legacy ADMIN_EMAIL).
+ */
+
+import { getAdminEmails, isAdminEmail } from '../../src/utils/admin-emails';
+
+describe('admin-emails', () => {
+  const ORIGINAL_ADMIN_EMAIL = process.env.ADMIN_EMAIL;
+  const ORIGINAL_ADMIN_EMAILS = process.env.ADMIN_EMAILS;
+
+  beforeEach(() => {
+    delete process.env.ADMIN_EMAIL;
+    delete process.env.ADMIN_EMAILS;
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_ADMIN_EMAIL === undefined) delete process.env.ADMIN_EMAIL;
+    else process.env.ADMIN_EMAIL = ORIGINAL_ADMIN_EMAIL;
+    if (ORIGINAL_ADMIN_EMAILS === undefined) delete process.env.ADMIN_EMAILS;
+    else process.env.ADMIN_EMAILS = ORIGINAL_ADMIN_EMAILS;
+  });
+
+  describe('getAdminEmails', () => {
+    it('returns an empty list when neither env var is set', () => {
+      expect(getAdminEmails()).toEqual([]);
+    });
+
+    it('parses a comma-separated ADMIN_EMAILS list (trimmed, lower-cased)', () => {
+      process.env.ADMIN_EMAILS = 'A@Example.com, b@example.com ,C@EXAMPLE.COM';
+      expect(getAdminEmails()).toEqual(['a@example.com', 'b@example.com', 'c@example.com']);
+    });
+
+    it('merges legacy ADMIN_EMAIL with ADMIN_EMAILS and de-duplicates', () => {
+      process.env.ADMIN_EMAIL = 'owner@example.com';
+      process.env.ADMIN_EMAILS = 'owner@example.com,helper@example.com';
+      expect(getAdminEmails().sort()).toEqual(['helper@example.com', 'owner@example.com']);
+    });
+
+    it('ignores empty entries and stray commas', () => {
+      process.env.ADMIN_EMAILS = ',,owner@example.com,, ,';
+      expect(getAdminEmails()).toEqual(['owner@example.com']);
+    });
+  });
+
+  describe('isAdminEmail', () => {
+    it('matches an email on the ADMIN_EMAILS list case-insensitively', () => {
+      process.env.ADMIN_EMAILS = 'owner@example.com,helper@example.com';
+      expect(isAdminEmail('Helper@Example.com')).toBe(true);
+      expect(isAdminEmail(' owner@example.com ')).toBe(true);
+    });
+
+    it('still honors the legacy single ADMIN_EMAIL', () => {
+      process.env.ADMIN_EMAIL = 'owner@example.com';
+      expect(isAdminEmail('owner@example.com')).toBe(true);
+    });
+
+    it('returns false for non-admin, empty, null, or undefined emails', () => {
+      process.env.ADMIN_EMAILS = 'owner@example.com';
+      expect(isAdminEmail('someoneelse@example.com')).toBe(false);
+      expect(isAdminEmail('')).toBe(false);
+      expect(isAdminEmail(null)).toBe(false);
+      expect(isAdminEmail(undefined)).toBe(false);
+    });
+
+    it('returns false when no allowlist is configured', () => {
+      expect(isAdminEmail('owner@example.com')).toBe(false);
+    });
+  });
+});

--- a/docs/testing/workos-test-accounts.md
+++ b/docs/testing/workos-test-accounts.md
@@ -9,7 +9,7 @@ account to the role the plan needs.
 
 All personas use `+alias` addresses on the verified inbox so they (a) sign in as distinct
 WorkOS identities, (b) all deliver to one Gmail inbox, and (c) never collide with the ADMIN
-auto-assignment (which is an exact match on `ADMIN_EMAIL`, see `workos-service.ts`).
+auto-assignment (the allowlist match in `workos-service.ts` — see "Adding an admin tester" below).
 
 | Persona | Sign-in email | System `User.role` | Team linkage | Receives email? |
 |---|---|---|---|---|
@@ -107,6 +107,28 @@ are, three things to know:
   is the simplest way to exercise the export paths.
 
 See `backend/src/services/entitlements/` and `backend/src/api/middleware/entitlements.ts`.
+
+## Adding an admin tester
+
+ADMIN is granted **only at first sign-up**, to emails on an allowlist read from env
+(`ADMIN_EMAILS`, comma-separated; legacy single `ADMIN_EMAIL` still honored), case-insensitive —
+see `backend/src/utils/admin-emails.ts`. There is no in-app "make admin" action, and re-login
+never changes an existing user's role.
+
+To add a tester (e.g. a second admin):
+
+1. **If they have NOT signed up yet** — add their email to the `ADMIN_EMAILS` allowlist and deploy
+   *before* they sign up. Set it in `infra/task-definition.json` (and `admin_emails` in your
+   Terraform vars / `infra/ecs.tf`), then roll the ECS service. They get ADMIN automatically on
+   first sign-up.
+2. **If they have ALREADY signed up** — the allowlist won't retroactively promote them. Update the
+   DB directly:
+
+   ```sql
+   UPDATE "User" SET role = 'ADMIN' WHERE email = 'their-email@example.com';
+   ```
+
+   (Point at the production DB from `bball-tracker-production/database-url` in Secrets Manager.)
 
 ## Gotchas
 

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -207,6 +207,7 @@ resource "aws_ecs_task_definition" "app" {
       { name = "WORKOS_REDIRECT_URI", value = "https://api.${var.domain_name}/api/v1/auth/callback" },
       { name = "CORS_ORIGIN", value = "https://api.${var.domain_name}" },
       { name = "ADMIN_EMAIL", value = var.admin_email },
+      { name = "ADMIN_EMAILS", value = var.admin_emails },
       { name = "S3_AVATARS_BUCKET", value = aws_s3_bucket.avatars.id },
       { name = "AWS_REGION", value = var.aws_region },
     ]

--- a/infra/task-definition.json
+++ b/infra/task-definition.json
@@ -24,6 +24,7 @@
         { "name": "WORKOS_REDIRECT_URI", "value": "https://api.capyhoops.com/api/v1/auth/callback" },
         { "name": "CORS_ORIGIN", "value": "https://api.capyhoops.com" },
         { "name": "ADMIN_EMAIL", "value": "deasystephen@gmail.com" },
+        { "name": "ADMIN_EMAILS", "value": "deasystephen@gmail.com,ellardeasy@gmail.com" },
         { "name": "SENTRY_ENVIRONMENT", "value": "production" },
         { "name": "SENTRY_RELEASE", "value": "SENTRY_RELEASE_PLACEHOLDER" },
         { "name": "AWS_SES_REGION", "value": "us-east-1" },

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -18,3 +18,6 @@ workos_client_id = ""
 
 # Domain (ACM certificate is managed automatically via dns.tf)
 domain_name = "capyhoops.com"
+
+# Admin allowlist — comma-separated emails granted ADMIN role on first sign-up
+admin_emails = "owner@example.com,helper@example.com"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -142,7 +142,13 @@ variable "domain_name" {
 
 # Admin
 variable "admin_email" {
-  description = "Email address that gets ADMIN role on first sign-up"
+  description = "Single email that gets ADMIN role on first sign-up (legacy; prefer admin_emails)"
+  type        = string
+  default     = ""
+}
+
+variable "admin_emails" {
+  description = "Comma-separated allowlist of emails that get ADMIN role on first sign-up"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary

Adds a config-driven **admin allowlist** so additional accounts (e.g. testers) can be granted the `ADMIN` role at first sign-up, instead of the single hard-coded `ADMIN_EMAIL`. Motivated by adding `ellardeasy@gmail.com` as a second admin tester.

## Changes

- **`backend/src/utils/admin-emails.ts`** (new) — `getAdminEmails()` / `isAdminEmail()` read a comma-separated `ADMIN_EMAILS` list, still honoring the legacy single `ADMIN_EMAIL`, **case-insensitive** and de-duplicated.
- **`workos-service.ts`** — use `isAdminEmail()` when assigning the role on user create (was `process.env.ADMIN_EMAIL === workosUser.email`).
- **infra** — add an `admin_emails` Terraform variable + `ADMIN_EMAILS` env (`ecs.tf`, `variables.tf`, `terraform.tfvars.example`), and set it in `task-definition.json` to `deasystephen@gmail.com,ellardeasy@gmail.com`.
- **docs** — `workos-test-accounts.md` gains an "Adding an admin tester" section.
- **tests** — `admin-emails.test.ts` covers list parsing, legacy merge, case-insensitivity, trimming, and empty/null inputs.

## Important behavior note

This governs role assignment **at account creation only**. It does **not** retroactively promote existing accounts — `syncUser` never rewrites an existing user's role.

So for `ellardeasy@gmail.com` (not signed up yet): once this is **deployed**, she gets `ADMIN` automatically on first sign-up. If she happens to sign up *before* the deploy, promote her existing row with:

```sql
UPDATE "User" SET role = 'ADMIN' WHERE email = 'ellardeasy@gmail.com';
```

## Verification

- `admin-emails.test.ts`: 8/8 pass. `workos-service` suite still green (no admin env in tests → users default to `PLAYER`, unchanged).
- `npx tsc --noEmit` clean; `eslint .` reports 0 errors (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sh96Np2m7rVogmxSJHj2LX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sh96Np2m7rVogmxSJHj2LX)_