### PR TITLE
fix(mobile): add auth/callback route + Sentry error reporting

### DIFF
--- a/.maestro/auth-callback.yaml
+++ b/.maestro/auth-callback.yaml
@@ -1,0 +1,21 @@
+appId: com.bballtracker.mobile
+---
+# Regression guard for the WorkOS OAuth callback deep link.
+#
+# The redirect bball-tracker://auth/callback?code=… must resolve to the
+# app/auth/callback.tsx route. Before that route existed, the deep link fell
+# through to Expo Router's "Unmatched Route" screen (see the fix in
+# app/auth/callback.tsx). A full success run needs a live WorkOS code exchange,
+# so this flow exercises the deterministic error branch instead: an error in
+# the callback params must render the recoverable "Sign In Failed" screen —
+# proving the route resolves — and never the "Unmatched Route" fallback.
+- launchApp:
+    clearState: true
+# Deep-link straight into the callback route with an OAuth error param.
+- openLink: "bball-tracker://auth/callback?error=access_denied"
+# The route resolved and rendered our error UI (not Expo Router's fallback).
+- assertVisible: "Sign In Failed"
+- assertNotVisible: "Unmatched Route"
+# The recovery action returns the user to the sign-in screen.
+- tapOn: "Back to Sign In"
+- assertVisible: "Basketball Tracker"

--- a/mobile/__tests__/services/sentry.test.ts
+++ b/mobile/__tests__/services/sentry.test.ts
@@ -11,6 +11,7 @@
 jest.mock('@sentry/react-native', () => ({
   init: jest.fn(),
   setUser: jest.fn(),
+  captureException: jest.fn(),
 }));
 
 jest.mock('expo-constants', () => ({
@@ -28,6 +29,7 @@ import Constants from 'expo-constants';
 
 const sentryInit = Sentry.init as jest.Mock;
 const sentrySetUser = Sentry.setUser as jest.Mock;
+const sentryCaptureException = Sentry.captureException as jest.Mock;
 
 // Each test re-imports the module so the `initialized` module-level flag
 // starts fresh.
@@ -248,6 +250,44 @@ describe('services/sentry', () => {
       const { initSentry, setSentryUser } = loadSentryModule();
       initSentry();
       expect(() => setSentryUser('u1')).not.toThrow();
+    });
+  });
+
+  describe('captureException', () => {
+    it('no-ops when Sentry is not initialized', () => {
+      const { captureException } = loadSentryModule();
+      captureException(new Error('boom'));
+      expect(sentryCaptureException).not.toHaveBeenCalled();
+    });
+
+    it('forwards the error to Sentry after init', () => {
+      setExtra({ sentryDsn: 'https://test@sentry.io/1' });
+      const { initSentry, captureException } = loadSentryModule();
+      initSentry();
+      const err = new Error('boom');
+      captureException(err);
+      expect(sentryCaptureException).toHaveBeenCalledWith(err, undefined);
+    });
+
+    it('attaches context under the app namespace when provided', () => {
+      setExtra({ sentryDsn: 'https://test@sentry.io/1' });
+      const { initSentry, captureException } = loadSentryModule();
+      initSentry();
+      const err = new Error('boom');
+      captureException(err, { flow: 'auth-callback' });
+      expect(sentryCaptureException).toHaveBeenCalledWith(err, {
+        contexts: { app: { flow: 'auth-callback' } },
+      });
+    });
+
+    it('swallows errors from Sentry.captureException', () => {
+      setExtra({ sentryDsn: 'https://test@sentry.io/1' });
+      sentryCaptureException.mockImplementationOnce(() => {
+        throw new Error('nope');
+      });
+      const { initSentry, captureException } = loadSentryModule();
+      initSentry();
+      expect(() => captureException(new Error('boom'))).not.toThrow();
     });
   });
 });

--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -16,7 +16,7 @@ export default {
   expo: {
     name: IS_PRODUCTION ? 'Basketball Tracker' : `Basketball Tracker (${process.env.APP_ENV || 'dev'})`,
     slug: 'bball-tracker',
-    version: '1.0.0',
+    version: '1.1.0',
     orientation: 'portrait',
     icon: './assets/icon.png',
     userInterfaceStyle: 'light',

--- a/mobile/app/auth/callback.tsx
+++ b/mobile/app/auth/callback.tsx
@@ -19,6 +19,17 @@ import { apiClient } from '../../services/api-client';
 import { captureException } from '../../services/sentry';
 import { spacing } from '../../theme';
 
+/**
+ * Errors that are knowable from the deep link itself (WorkOS returned an error,
+ * or no code came back) are derived during render — no effect/state needed.
+ * Only the async token-exchange failure has to live in state.
+ */
+function getParamError(oauthError?: string, code?: string): string | null {
+  if (oauthError) return oauthError;
+  if (!code) return 'No authorization code was returned. Please try signing in again.';
+  return null;
+}
+
 export default function AuthCallbackScreen() {
   const router = useRouter();
   const { colors } = useTheme();
@@ -28,23 +39,15 @@ export default function AuthCallbackScreen() {
     error?: string;
   }>();
 
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const paramError = getParamError(oauthError, code);
+  const [exchangeError, setExchangeError] = useState<string | null>(null);
   // Guard so the code is only exchanged once, even if the effect re-runs.
   const exchangedRef = useRef(false);
 
   useEffect(() => {
+    if (paramError || !code) return;
     if (exchangedRef.current) return;
     exchangedRef.current = true;
-
-    if (oauthError) {
-      setErrorMessage(oauthError);
-      return;
-    }
-
-    if (!code) {
-      setErrorMessage('No authorization code was returned. Please try signing in again.');
-      return;
-    }
 
     (async () => {
       try {
@@ -58,10 +61,12 @@ export default function AuthCallbackScreen() {
       } catch (err) {
         captureException(err, { flow: 'auth-callback' });
         console.error('Token exchange error:', err);
-        setErrorMessage('Failed to complete sign in. Please try again.');
+        setExchangeError('Failed to complete sign in. Please try again.');
       }
     })();
-  }, [code, oauthError, router, setAuthToken, setUser]);
+  }, [code, paramError, router, setAuthToken, setUser]);
+
+  const errorMessage = paramError ?? exchangeError;
 
   if (errorMessage) {
     return (

--- a/mobile/app/auth/callback.tsx
+++ b/mobile/app/auth/callback.tsx
@@ -1,0 +1,109 @@
+/**
+ * OAuth callback route for bball-tracker://auth/callback?code=<code>
+ *
+ * WorkOS redirects the browser back to this deep link after the user signs in.
+ * Expo Router matches the path to this screen, which exchanges the authorization
+ * code for a session token and then routes the user into the app. Without a real
+ * route here, the incoming deep link lands on Expo Router's "Unmatched Route"
+ * screen (see login.tsx's redirect URI built with `Linking.createURL('auth/callback')`).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { ThemedView, ThemedText, LoadingSpinner, Button } from '../../components';
+import { useTheme } from '../../hooks/useTheme';
+import { useAuthActions } from '../../store/auth-store';
+import { apiClient } from '../../services/api-client';
+import { captureException } from '../../services/sentry';
+import { spacing } from '../../theme';
+
+export default function AuthCallbackScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const { setAuthToken, setUser } = useAuthActions();
+  const { code, error: oauthError } = useLocalSearchParams<{
+    code?: string;
+    error?: string;
+  }>();
+
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  // Guard so the code is only exchanged once, even if the effect re-runs.
+  const exchangedRef = useRef(false);
+
+  useEffect(() => {
+    if (exchangedRef.current) return;
+    exchangedRef.current = true;
+
+    if (oauthError) {
+      setErrorMessage(oauthError);
+      return;
+    }
+
+    if (!code) {
+      setErrorMessage('No authorization code was returned. Please try signing in again.');
+      return;
+    }
+
+    (async () => {
+      try {
+        const response = await apiClient.get('/auth/callback', { params: { code } });
+        const { accessToken, user } = response.data;
+
+        setAuthToken(accessToken);
+        setUser(user);
+
+        router.replace('/(tabs)/home');
+      } catch (err) {
+        captureException(err, { flow: 'auth-callback' });
+        console.error('Token exchange error:', err);
+        setErrorMessage('Failed to complete sign in. Please try again.');
+      }
+    })();
+  }, [code, oauthError, router, setAuthToken, setUser]);
+
+  if (errorMessage) {
+    return (
+      <ThemedView variant="background" style={styles.container}>
+        <View style={styles.content}>
+          <Ionicons name="close-circle-outline" size={64} color={colors.error} />
+          <ThemedText variant="h2" style={styles.title}>
+            Sign In Failed
+          </ThemedText>
+          <ThemedText variant="body" color="textSecondary" style={styles.subtitle}>
+            {errorMessage}
+          </ThemedText>
+          <Button title="Back to Sign In" onPress={() => router.replace('/login')} style={styles.btn} />
+        </View>
+      </ThemedView>
+    );
+  }
+
+  return <LoadingSpinner message="Signing you in…" fullScreen />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.xl,
+  },
+  title: {
+    textAlign: 'center',
+    marginTop: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  subtitle: {
+    textAlign: 'center',
+    marginBottom: spacing.lg,
+  },
+  btn: {
+    marginTop: spacing.md,
+    width: '100%',
+  },
+});

--- a/mobile/app/login.tsx
+++ b/mobile/app/login.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, Modal, FlatList, ActivityIndicator } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
 import * as Linking from 'expo-linking';
 import { useAuthStore } from '../store/auth-store';
 import { apiClient } from '../services/api-client';
+import { captureException } from '../services/sentry';
 import { useTheme } from '../hooks/useTheme';
 import { spacing } from '../theme';
 import { borderRadius } from '../theme/border-radius';
@@ -27,63 +28,9 @@ export default function Login() {
   const [showDevLogin, setShowDevLogin] = useState(false);
   const [devUsers, setDevUsers] = useState<DevUser[]>([]);
 
-  // Handle deep link callback from OAuth redirect
-  useEffect(() => {
-    const handleDeepLink = async (event: { url: string }) => {
-      const { url } = event;
-      const parsed = Linking.parse(url);
-
-      // Check if this is an auth callback
-      if (parsed.path === 'auth/callback' || parsed.queryParams?.code) {
-        const code = parsed.queryParams?.code as string;
-        const error = parsed.queryParams?.error as string | undefined;
-
-        if (error) {
-          Alert.alert('Authentication Error', error);
-          setIsLoading(false);
-          return;
-        }
-
-        if (code) {
-          try {
-            setIsLoading(true);
-            // Exchange code for token via backend
-            const response = await apiClient.get('/auth/callback', {
-              params: { code },
-            });
-
-            const { accessToken, user } = response.data;
-
-            // Store token and user
-            setAuthToken(accessToken);
-            setUser(user);
-
-            // Navigate to home
-            router.replace('/(tabs)/home');
-          } catch (error) {
-            console.error('Token exchange error:', error);
-            Alert.alert('Error', 'Failed to complete authentication. Please try again.');
-          } finally {
-            setIsLoading(false);
-          }
-        }
-      }
-    };
-
-    // Listen for deep links
-    const subscription = Linking.addEventListener('url', handleDeepLink);
-
-    // Check if app was opened via deep link
-    Linking.getInitialURL().then((url) => {
-      if (url) {
-        handleDeepLink({ url });
-      }
-    });
-
-    return () => {
-      subscription.remove();
-    };
-  }, [router, setAuthToken, setUser]);
+  // The OAuth redirect (bball-tracker://auth/callback?code=…) is handled by the
+  // dedicated `app/auth/callback.tsx` route, which Expo Router matches on the
+  // incoming deep link and which exchanges the code for a session token.
 
   const handleLogin = async () => {
     try {
@@ -108,6 +55,7 @@ export default function Login() {
         setIsLoading(false);
       }
     } catch (error) {
+      captureException(error, { flow: 'login-initiate' });
       console.error('Login error:', error);
       Alert.alert('Error', 'Failed to initiate login. Please try again.');
       setIsLoading(false);

--- a/mobile/components/ErrorBoundary.tsx
+++ b/mobile/components/ErrorBoundary.tsx
@@ -6,6 +6,7 @@
 import React, { Component, ErrorInfo } from 'react';
 import { View, StyleSheet, TouchableOpacity, Text } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { captureException } from '../services/sentry';
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
@@ -28,6 +29,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    captureException(error, { componentStack: errorInfo.componentStack });
     if (__DEV__) {
       console.error('ErrorBoundary caught an error:', error, errorInfo);
     }

--- a/mobile/services/sentry.ts
+++ b/mobile/services/sentry.ts
@@ -86,7 +86,6 @@ export function initSentry(): void {
   const dsn = (extra?.sentryDsn as string | undefined) || process.env.SENTRY_DSN;
   if (!dsn) {
     if (__DEV__) {
-      // eslint-disable-next-line no-console
       console.log('[Sentry] No DSN configured, skipping initialization');
     }
     return;
@@ -117,7 +116,6 @@ export function initSentry(): void {
     initialized = true;
   } catch (error) {
     if (__DEV__) {
-      // eslint-disable-next-line no-console
       console.warn('[Sentry] Failed to initialize:', error);
     }
   }

--- a/mobile/services/sentry.ts
+++ b/mobile/services/sentry.ts
@@ -148,6 +148,28 @@ export function setSentryUser(userId: string | null): void {
   }
 }
 
+/**
+ * Report a caught exception to Sentry.
+ *
+ * No-op until init has run (dev, or production without a DSN wired), so callers
+ * can wire it into catch blocks unconditionally. Optional `context` is attached
+ * as event contexts and runs through `beforeSend` scrubbing like any other event.
+ */
+export function captureException(
+  error: unknown,
+  context?: Record<string, unknown>
+): void {
+  if (!initialized) return;
+  try {
+    Sentry.captureException(
+      error,
+      context ? { contexts: { app: context } } : undefined
+    );
+  } catch {
+    // swallow — error reporting must never throw into the caller's catch block
+  }
+}
+
 export function isSentryEnabled(): boolean {
   return initialized;
 }


### PR DESCRIPTION
## Problem
After WorkOS sign-in, the OAuth redirect `bball-tracker://auth/callback?code=…` had **no matching Expo Router route**, so the deep link landed on the **"Unmatched Route"** screen and sign-in never completed. The old workaround listened for the link via `Linking.addEventListener` inside `login.tsx`, which raced Expo Router's own routing and tore down when `Login` unmounted.

Surfaced while running the E2E sign-up flow on TestFlight.

## Changes
- **`app/auth/callback.tsx`** (new route): exchanges the code for a session token, shows a "Signing you in…" loading state, and renders a recoverable "Sign In Failed" screen on error. Param-level errors (oauth error / missing code) are derived during render; only the async exchange failure lives in state.
- **`login.tsx`**: removed the obsolete `Linking.addEventListener` workaround.
- **Sentry reporting**: added a `captureException()` helper (gated on init, swallows its own errors) and wired it into the `ErrorBoundary`, the auth-callback catch, and the login-initiate catch — these previously only `console.error`'d, so real errors never reached Sentry.
- **Lint cleanup** (eslint now runs locally): dropped two dead `eslint-disable no-console` directives in `sentry.ts`.
- **`.maestro/auth-callback.yaml`**: first deep-link Maestro flow — guards against the "Unmatched Route" regression via the error branch.
- **`app.config.js`**: version `1.0.0` → `1.1.0`. Reconciles the marketing version onto mainline (the 1.1.0 bump shipped in TestFlight #19 was only ever on the local `release/mobile-v1.1.0` branch, never merged — leaving `main` at 1.0.0). Keeps `runtimeVersion` (appVersion policy) at 1.1.0, on the same OTA train as #19.

## Verification
- `tsc --noEmit` clean; `jest` 445/445 passing (4 new `captureException` tests).
- Built + submitted as **TestFlight build #21** (v1.1.0, build ID `58ea9d7d`) for re-testing.

## Follow-ups
- Merging this finally brings the 1.1.0 bump onto `main`; the one-off `release/mobile-v1.1.0` branch can then be deleted and all future builds cut from `main`.
- Depends on nothing, but pairs with #212 (eas-cli minimatch fix) for a clean local toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)