### PR TITLE
docs: drop references to the deleted develop branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 permissions:
   contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ The fix: Add API integration tests AND schema validation tests for every endpoin
 
 ## Git Workflow
 
-- Main branches: `main` and `develop`
+- Single long-lived branch: `main`. All work happens on short-lived feature branches that merge back into `main` via PR.
 - Feature branches from `main`: `feature/your-feature-name`
 - Use conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`
 - **Tagging**: When pushing major changes to GitHub (new features, design overhauls, large refactors), create an annotated tag with `git tag -a vX.Y.Z -m "description"` and push it with `git push origin vX.Y.Z`. Use semantic versioning:

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -41,7 +41,7 @@ module.exports = {
       // middleware and #43 usage-metering code into this branch added functions
       // whose coverage lands the merged-tree global at 86.41%. Ratcheted to the
       // achieved floor so the gate stays deterministic; this still matches
-      // develop's existing function gate (no regression below it).
+      // the prior function gate (no regression below it).
       functions: 86,
       lines: 84,
       statements: 84,

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -42,7 +42,7 @@ module.exports = {
       // 71 (not the originally proposed 72): merging #43's usage-metering
       // mobile UI (UsageMeter, useUsage, Profile card) into this branch lands
       // the merged-tree branch coverage at 71.61%. Ratcheted to the achieved
-      // floor; still a large increase over develop's baseline (58).
+      // floor; still a large increase over the prior baseline (58).
       branches: 71,
       functions: 73,
       lines: 74,


### PR DESCRIPTION
The repo now uses a single long-lived branch (`main`); all work happens on short-lived feature branches merged back via PR. The `develop` branch no longer exists on the remote, so its references are stale.

## Changes
- **`CLAUDE.md`** Git Workflow: describe the main-only feature-branch model instead of listing `main` and `develop` as main branches.
- **`.github/workflows/ci.yml`**: drop `develop` from the `push` and `pull_request` branch filters — it pointed at a non-existent branch.
- **`backend/` & `mobile/` `jest.config.js`**: reword the coverage-floor comments that cited "develop's baseline" to "the prior baseline". **Coverage thresholds are unchanged.**

No functional behavior changes; CI triggers are unaffected for `main` and PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)