### PR TITLE
fix(backend): enable TLS for pg adapter so RDS accepts runtime connections

### DIFF
--- a/backend/src/api/auth/routes.ts
+++ b/backend/src/api/auth/routes.ts
@@ -8,6 +8,7 @@ import { UnauthorizedError, BadRequestError } from '../../utils/errors';
 import prisma from '../../models';
 import { authRateLimit } from '../middleware/rate-limit';
 import { logger } from '../../utils/logger';
+import { captureException } from '../../utils/sentry';
 import { authenticate } from './middleware';
 import { getEffectiveTier, getAllFeatures, getUsageLimits } from '../../utils/entitlements';
 import { NotificationService } from '../../services/notification-service';
@@ -216,6 +217,9 @@ router.get('/callback', async (req, res) => {
     if (error instanceof BadRequestError) {
       res.status(400).json({ error: error.message });
     } else {
+      // Unexpected failure (e.g. DB/WorkOS outage) — report to Sentry so we're
+      // alerted instead of only finding it in CloudWatch logs after a user hits it.
+      captureException(error, { flow: 'auth-callback' });
       res.status(500).json({ error: 'Authentication failed' });
     }
   }
@@ -265,6 +269,7 @@ router.get('/me', async (req, res) => {
     if (error instanceof UnauthorizedError) {
       res.status(401).json({ error: error.message });
     } else {
+      captureException(error, { flow: 'auth-me' });
       res.status(500).json({ error: 'Failed to get user information' });
     }
   }
@@ -300,6 +305,7 @@ router.get('/me/usage', authenticate, async (req, res) => {
     logger.error('Error getting usage', {
       error: error instanceof Error ? error.message : String(error),
     });
+    captureException(error, { flow: 'auth-usage' });
     res.status(500).json({ error: 'Failed to get usage' });
   }
 });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -64,9 +64,26 @@ app.use(express.urlencoded({ extended: true, limit: '1mb' }));
 app.use(requestContext);
 app.use(requestLogger);
 
-// Health check endpoint
-app.get('/health', (_req, res) => {
-  res.json({ status: 'ok', timestamp: new Date().toISOString() });
+// Health check endpoint.
+// This backs the ECS container health check, so it pings the database: a
+// healthy process that cannot reach the DB is useless (every request 500s), and
+// a static 200 here previously let a total DB outage masquerade as "healthy"
+// while all sign-ins failed. A failed ping returns 503 (marking the task
+// unhealthy so ECS recycles it) and reports to Sentry.
+import prisma from './models';
+import { captureException } from './utils/sentry';
+
+app.get('/health', async (_req, res) => {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    res.json({ status: 'ok', db: 'ok', timestamp: new Date().toISOString() });
+  } catch (err) {
+    logger.error('Health check DB ping failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    captureException(err, { flow: 'health-check' });
+    res.status(503).json({ status: 'degraded', db: 'down', timestamp: new Date().toISOString() });
+  }
 });
 
 // Rate limiting

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -6,7 +6,24 @@
 import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 
-const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+const connectionString = process.env.DATABASE_URL!;
+
+/**
+ * RDS enforces TLS (`rds.force_ssl = 1`), and unlike Prisma's old Rust engine,
+ * the `@prisma/adapter-pg` driver (node-postgres) does NOT negotiate TLS unless
+ * we explicitly enable it — a non-SSL connection is rejected with a `28000`
+ * "no pg_hba.conf entry ... no encryption" error that Prisma surfaces as the
+ * misleading "P1010 denied access". Local dev Postgres (docker-compose) has no
+ * TLS, so SSL is skipped for localhost. `rejectUnauthorized: false` keeps the
+ * connection encrypted without pinning the RDS CA bundle (the app runs inside a
+ * private VPC); see follow-up to pin the Amazon RDS CA for full verification.
+ */
+const isLocalDb = /@(localhost|127\.0\.0\.1)[:/]/.test(connectionString);
+
+const adapter = new PrismaPg({
+  connectionString,
+  ...(isLocalDb ? {} : { ssl: { rejectUnauthorized: false } }),
+});
 
 const prisma = new PrismaClient({
   adapter,

--- a/backend/src/utils/sentry.ts
+++ b/backend/src/utils/sentry.ts
@@ -131,6 +131,23 @@ export function isSentryEnabled(): boolean {
 }
 
 /**
+ * Report an error to Sentry from inside a route handler that catches and
+ * swallows the error (responding with its own status) instead of delegating to
+ * the central `sentryErrorHandler` middleware. No-ops when Sentry is disabled.
+ * `tags` attach context (e.g. `{ flow: 'auth-callback' }`) to aid triage.
+ */
+export function captureException(
+  error: unknown,
+  tags?: Record<string, string>
+): void {
+  if (!initialized) return;
+  Sentry.withScope(scope => {
+    if (tags) scope.setTags(tags);
+    Sentry.captureException(error);
+  });
+}
+
+/**
  * Express error handler that forwards the error to Sentry (if enabled) before
  * calling `next(err)` so downstream handlers still run.
  */

--- a/backend/tests/api/auth.test.ts
+++ b/backend/tests/api/auth.test.ts
@@ -17,8 +17,17 @@ jest.mock('../../src/models', () => ({
   },
 }));
 
+// Spy on Sentry capture while keeping the rest of the util real (index.ts needs
+// initSentry / sentryErrorHandler at import time).
+jest.mock('../../src/utils/sentry', () => ({
+  ...jest.requireActual('../../src/utils/sentry'),
+  captureException: jest.fn(),
+}));
+import { captureException } from '../../src/utils/sentry';
+
 const mockWorkOSService = WorkOSService as jest.Mocked<typeof WorkOSService>;
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockCaptureException = captureException as jest.Mock;
 
 describe('Auth API', () => {
   const mockUser = {
@@ -179,6 +188,11 @@ describe('Auth API', () => {
 
       expect(response.status).toBe(500);
       expect(response.body.error).toBe('Authentication failed');
+      // Unexpected failures must be reported to Sentry (the prior gap: the
+      // callback only logged to CloudWatch, so a DB outage was invisible).
+      expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error), {
+        flow: 'auth-callback',
+      });
     });
   });
 

--- a/backend/tests/health.test.ts
+++ b/backend/tests/health.test.ts
@@ -1,12 +1,28 @@
 import request from 'supertest';
 import { app, httpServer } from '../src/index';
+import { mockPrisma } from './setup';
 
 describe('Health Check', () => {
-  it('should return 200 and status ok', async () => {
+  it('should return 200 and status ok when the DB ping succeeds', async () => {
+    (mockPrisma.$queryRaw as jest.Mock).mockResolvedValueOnce([{ '?column?': 1 }]);
+
     const response = await request(app).get('/health');
     expect(response.status).toBe(200);
     expect(response.body.status).toBe('ok');
+    expect(response.body.db).toBe('ok');
     expect(response.body.timestamp).toBeDefined();
+    expect(mockPrisma.$queryRaw).toHaveBeenCalled();
+  });
+
+  it('should return 503 degraded when the DB is unreachable', async () => {
+    (mockPrisma.$queryRaw as jest.Mock).mockRejectedValueOnce(
+      new Error('no pg_hba.conf entry ... no encryption')
+    );
+
+    const response = await request(app).get('/health');
+    expect(response.status).toBe(503);
+    expect(response.body.status).toBe('degraded');
+    expect(response.body.db).toBe('down');
   });
 });
 

--- a/backend/tests/setup.ts
+++ b/backend/tests/setup.ts
@@ -190,6 +190,7 @@ export const mockPrisma = {
     count: jest.fn(),
   },
   $transaction: jest.fn(),
+  $queryRaw: jest.fn().mockResolvedValue([{ '?column?': 1 }]),
   $disconnect: jest.fn(),
 };
 


### PR DESCRIPTION
## Production incident: all sign-ins failing with a 500

Reported via the mobile **\"Sign In Failed\"** screen (Sentry issue `BBALL-TRACKER-MOBILE-2`, tagged `flow: auth-callback`). WorkOS sign-in succeeded; the app got a **500 from `GET /api/v1/auth/callback`**.

## Root cause

The **Prisma 6→7 upgrade (`1124c91`)** moved runtime queries onto `@prisma/adapter-pg` (node-postgres). node-`pg` **does not negotiate TLS unless explicitly told to**, and RDS has **`rds.force_ssl = 1`** (the Postgres 15 default). So every runtime query was rejected with Postgres `28000`:

```
no pg_hba.conf entry for host "...", user "bball_admin", database "bball_tracker", no encryption
```

Prisma surfaces `28000` as the misleading **"P1010 denied access"**. The failure hit the very first DB query in the callback (`syncUser` → `findFirst`), so the backend returned a generic `500 { error: 'Authentication failed' }`.

**Why it looked healthy:** `prisma migrate deploy` (Prisma's own engine, runs at container boot) negotiates TLS automatically, so the container booted clean and never crashlooped. And `/health` returned a static 200 without touching the DB. Every sign-in had been broken since ~2026-06-21 00:00 UTC (when the Prisma 7 image deployed).

Verified the fix against production RDS via a throwaway one-off ECS task: with SSL enabled the adapter connects over **TLSv1.2** and reads the `User` table. (Diagnostic task defs deregistered; running service untouched.)

## Changes

- **`models/index.ts`** — enable SSL on `PrismaPg` for non-local hosts (`rejectUnauthorized: false`; localhost/dev skipped). *Follow-up:* pin the Amazon RDS CA bundle for full cert verification.
- **`auth/routes.ts`** — report swallowed 500s (`callback` / `me` / `me/usage`) to Sentry. These catch blocks previously logged only to CloudWatch, so the **backend Sentry project was silent** during the outage — the gap that hid this.
- **`index.ts` `/health`** — ping the DB (`SELECT 1`) and return **503** on failure, so the ECS container health check marks the task unhealthy instead of a static 200 masking a dead DB.
- **Tests** — `/health` DB-down 503 path, auth-callback Sentry capture, `$queryRaw` mock. Full suite green (**938 passing / 56 suites**).

## Notes for review

- `/health` is now DB-dependent (it backs the ECS liveness check). For this single-task, pre-launch app a loud failure is preferable to silent; revisit if/when liveness and readiness need splitting.
- `rejectUnauthorized: false` keeps the connection encrypted without pinning the RDS CA (app runs inside a private VPC). Follow-up issue worth filing for CA pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)