### PR TITLE
fix(mobile): wrap useAuthActions in useShallow to stop a render loop

### DIFF
--- a/mobile/__tests__/store/auth-store.test.ts
+++ b/mobile/__tests__/store/auth-store.test.ts
@@ -16,7 +16,13 @@ jest.mock('../../services/analytics', () => ({
   },
 }));
 
-import { useAuthStore, useAuthUser, useIsAuthenticated } from '../../store/auth-store';
+import { renderHook } from '@testing-library/react-native';
+import {
+  useAuthStore,
+  useAuthUser,
+  useIsAuthenticated,
+  useAuthActions,
+} from '../../store/auth-store';
 import {
   trackEvent,
   identifyUser,
@@ -113,5 +119,21 @@ describe('auth-store', () => {
     // Smoke check the selector references exist and are functions.
     expect(typeof useAuthUser).toBe('function');
     expect(typeof useIsAuthenticated).toBe('function');
+  });
+
+  // Regression: useAuthActions must return a referentially-stable object across
+  // re-renders. Without `useShallow` (Zustand v5) it returned a new object every
+  // render, so useSyncExternalStore's snapshot looked changed each render and
+  // AuthCallbackScreen hit "Maximum update depth exceeded" (Sentry MOBILE-1).
+  it('useAuthActions returns a stable reference across re-renders', () => {
+    const { result, rerender } = renderHook(() => useAuthActions());
+    const first = result.current;
+
+    rerender({});
+
+    expect(result.current).toBe(first);
+    expect(typeof first.setAuthToken).toBe('function');
+    expect(typeof first.setUser).toBe('function');
+    expect(typeof first.logout).toBe('function');
   });
 });

--- a/mobile/store/auth-store.ts
+++ b/mobile/store/auth-store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { User, UserRole } from '../../shared/types';
@@ -76,9 +77,16 @@ export const useAuthStore = create<AuthState>()(
  */
 export const useAuthUser = () => useAuthStore((state) => state.user);
 export const useIsAuthenticated = () => useAuthStore((state) => state.isAuthenticated);
+// Zustand v5 removed the `shallow` equality argument: a selector returning a
+// new object every render makes `useSyncExternalStore`'s snapshot look like it
+// changed on every render, causing an infinite re-render loop ("Maximum update
+// depth exceeded"). `useShallow` shallow-compares the result so the snapshot is
+// stable (the action fns are already stable store references).
 export const useAuthActions = () =>
-  useAuthStore((state) => ({
-    setAuthToken: state.setAuthToken,
-    setUser: state.setUser,
-    logout: state.logout,
-  }));
+  useAuthStore(
+    useShallow((state) => ({
+      setAuthToken: state.setAuthToken,
+      setUser: state.setUser,
+      logout: state.logout,
+    }))
+  );


### PR DESCRIPTION
Fixes Sentry **BBALL-TRACKER-MOBILE-1** ("Maximum update depth exceeded").

## Root cause

Zustand is **v5**, which removed the `shallow` equality argument to store hooks. `useAuthActions` selected a **new object** every render with no equality function:

```ts
useAuthStore((state) => ({ setAuthToken: ..., setUser: ..., logout: ... }))
```

So `useSyncExternalStore`'s snapshot looked changed on every render → infinite re-render loop → React's "Maximum update depth exceeded". The Sentry `componentStack` pinned it to **`AuthCallbackScreen`**, which is the **only consumer** of the **only object-returning selector** in the app — which is why it only showed up there.

The app stayed usable (React bails out the runaway updates) but it spammed Sentry on **every sign-in** (4 events / 2 test users), overlapping the login attempts during the DB outage.

## Fix

Wrap the selector in `useShallow` (the canonical v5 fix) so the snapshot is stable — the action functions are already stable store references, so a shallow compare returns the cached object.

Regression test added: `useAuthActions` returns a referentially-stable object across re-renders (fails on the old code, passes now).

## Deploy

JS-only — **OTA-eligible** via `eas update` to the production channel (runtime 1.1.0, build #21). No native rebuild needed. The fix isn't live on devices until an OTA is pushed; if anyone re-tests sign-in on the current build before then, the loop will re-fire and Sentry will auto-regress the issue (expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)