### PR TITLE
ci(backend): associate commits with Sentry release for auto-resolve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,12 @@ jobs:
           npx prisma generate
           npm run build
           npx @sentry/cli releases new "$SENTRY_RELEASE"
+          # Associate commits with this release so Sentry ingests commit messages
+          # and can auto-resolve issues referenced by "Fixes <SENTRY-SHORT-ID>".
+          # Requires the GitHub integration + repo linked in Sentry. --auto lets
+          # Sentry compute the commit range via the integration; --ignore-missing
+          # keeps a force-push/missing-commit edge case from failing the deploy.
+          npx @sentry/cli releases set-commits "$SENTRY_RELEASE" --auto --ignore-missing
           npx @sentry/cli sourcemaps upload --release "$SENTRY_RELEASE" ./dist
           npx @sentry/cli releases finalize "$SENTRY_RELEASE"
 


### PR DESCRIPTION
Enables Sentry's **resolve-via-commit** so `Fixes <SENTRY-SHORT-ID>` in a commit/PR auto-resolves the issue on deploy — the thing that *didn't* happen for MOBILE-1/MOBILE-2 (had to resolve manually).

## Why it wasn't working
The deploy job already does `releases new` → `sourcemaps upload` → `finalize` with `SENTRY_RELEASE=github.sha` (matching the app's release tag). But it never **associated commits** with the release, so Sentry had no commit messages to scan for the `Fixes …` keyword. Setting the release tag ≠ sending commit data.

## Change
One line, between `releases new` and `finalize`:
```bash
npx @sentry/cli releases set-commits "$SENTRY_RELEASE" --auto --ignore-missing
```
- `--auto` — Sentry computes the commit range via the GitHub integration (now installed + repo linked).
- `--ignore-missing` — a force-push / missing-commit edge case won't fail the deploy.

## Scope / caveats
- **Backend only.** Mobile (EAS/OTA) creates its own Sentry releases during source-map upload and needs the same `set-commits` wiring in the EAS build step — filed as a follow-up.
- Possible watch-item: the deploy checkout is shallow (`fetch-depth: 1`). `--auto` resolves commits server-side via the integration so this is normally fine; if the first post-merge release shows no associated commits, bumping the deploy job's checkout to `fetch-depth: 0` is the lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)