### PR TITLE
ci(mobile): associate commits with Sentry release on EAS build

### DIFF
--- a/mobile/scripts/sentry-upload-sourcemaps.js
+++ b/mobile/scripts/sentry-upload-sourcemaps.js
@@ -28,6 +28,15 @@ function run(cmd, args, opts = {}) {
   }
 }
 
+// Best-effort variant: warn but DON'T fail the build. Used for commit
+// association, which must never block a release if Sentry/the integration hiccups.
+function runSoft(cmd, args, opts = {}) {
+  const result = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+  if (result.status !== 0) {
+    console.warn(`[sentry] non-fatal: command failed: ${cmd} ${args.join(' ')}`);
+  }
+}
+
 function main() {
   const rawToken = process.env.SENTRY_AUTH_TOKEN;
   if (!rawToken) {
@@ -68,6 +77,12 @@ function main() {
 
   console.log(`[sentry] Uploading sourcemaps for release ${release}`);
   run('npx', ['@sentry/cli', 'releases', 'new', release]);
+  // Associate commits with the release so "Fixes <SENTRY-SHORT-ID>" in a commit
+  // auto-resolves the referenced mobile issue (parity with the backend deploy
+  // job). --auto resolves the repo + commit range via the Sentry GitHub
+  // integration; --ignore-missing tolerates EAS's shallow checkout. Best-effort:
+  // never fail a build over commit association.
+  runSoft('npx', ['@sentry/cli', 'releases', 'set-commits', release, '--auto', '--ignore-missing']);
   // @sentry/cli v2 replaced "releases files <rel> upload-sourcemaps <dir>"
   // with "sourcemaps upload --release <rel> <dir>".
   run('npx', ['@sentry/cli', 'sourcemaps', 'upload', '--release', release, distDir]);


### PR DESCRIPTION
Mobile parity with #219. Addresses #220.

## Change
Adds `@sentry/cli releases set-commits "<release>" --auto --ignore-missing` to the EAS `eas-build-on-success` hook (`mobile/scripts/sentry-upload-sourcemaps.js`), between `releases new` and `finalize`, so `Fixes <SENTRY-SHORT-ID>` in a commit auto-resolves the referenced **mobile** issue.

Runs via a new **`runSoft`** helper that warns instead of exiting — commit association must never fail a build (the existing `run()` hard-exits on non-zero).

## Important scope nuance (why this doesn't fully close #220)
This hook runs only on a **native `eas build`**, not on **`eas update` (OTA)**. So:
- ✅ Native builds: commits associated → auto-resolve works.
- ⚠️ OTA-only fixes (like MOBILE-1, shipped via `eas update`) **don't** auto-resolve at OTA time. Their commits get swept up by the **next native build's** `set-commits --auto` range, so they resolve eventually — just not immediately.
- Real-time OTA auto-resolve would need a `set-commits` step in an `eas update` CI flow, which doesn't exist yet (OTAs are run manually). Left open on #220.

## Verification
- Lint clean (script dir is lint-ignored), `node --check` passes, and the script still no-ops without `SENTRY_AUTH_TOKEN` (dev/PR builds unaffected).
- Real exercise happens on the next native EAS build; confirm by opening that build's release in Sentry and checking it lists associated commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)