### PR TITLE
chore(deps): bump mobile patch deps (2026-06-24)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -34,7 +34,7 @@
         "expo-splash-screen": "^55.0.21",
         "expo-status-bar": "^55.0.6",
         "expo-updates": "^55.0.24",
-        "i18next": "^26.3.1",
+        "i18next": "^26.3.2",
         "lottie-react-native": "^7.3.8",
         "moti": "^0.30.0",
         "react": "^19.2.7",
@@ -13020,9 +13020,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.3.1",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.1.tgz",
-      "integrity": "sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==",
+      "version": "26.3.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.2.tgz",
+      "integrity": "sha512-QQkXAM1sPDHqhxMQuBeHVMUn6mJchF+wdpOoQerciLAFqO3ZYdxO0EUbeEhruyutnNwpUQIITDVzLjwnNL0T1w==",
       "funding": [
         {
           "type": "individual",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -41,7 +41,7 @@
     "expo-splash-screen": "^55.0.21",
     "expo-status-bar": "^55.0.6",
     "expo-updates": "^55.0.24",
-    "i18next": "^26.3.1",
+    "i18next": "^26.3.2",
     "lottie-react-native": "^7.3.8",
     "moti": "^0.30.0",
     "react": "^19.2.7",


### PR DESCRIPTION
Lockfile-only caret patches surfaced by the Daily Upgrade Scan.

| Package  | From   | To     |
|----------|--------|--------|
| i18next  | 26.3.1 | 26.3.2 |

No high/critical CVEs in npm audit (47 moderate, unchanged). No Dependabot high/critical alerts on the default branch (5 alerts total: 4 moderate, 1 low).

## Test results

- `npm run type-check` — pass
- `npm test` — 446/446 pass
- `npx expo export --platform ios` — bundled successfully

Diff guard: only `mobile/package.json` and `mobile/package-lock.json` changed.

Generated by the Daily Upgrade Scan routine. See [docs/automation/daily-upgrade-scan.md](docs/automation/daily-upgrade-scan.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_017H8STniNBaWNwyDDLN2bf2)_