### PR TITLE
chore(deps): bump backend patch deps (2026-06-25)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/s3-request-presigner": "^3.1075.0",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
-        "@sentry/node": "^10.60.0",
+        "@sentry/node": "^10.61.0",
         "@workos-inc/node": "^8.13.0",
         "cors": "^2.8.5",
         "csv-stringify": "^6.8.0",
@@ -2684,28 +2684,28 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.60.0.tgz",
-      "integrity": "sha512-szN7ccOJAEaLb1BBQzCQhABGMTJmKNUk0G2sc7rWhajeXoZoMKIbNkI9RvJrFuV69cbad/d/BKGBjbpJhySAzw==",
+      "version": "10.61.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.61.0.tgz",
+      "integrity": "sha512-Edg8t2w45qEKiFnjeA6zRmU47R6la5FEMG+maZEOB2oTyJ+ujmh8LGaZ3G8aC0VdkKn8CXhHtDesze6oDc1oTA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.60.0.tgz",
-      "integrity": "sha512-u//paUrkKaCr0oNn7r7UulGydkYMSkU1wQOIpG/P/jf7psZWnyXhgeszHzUfZXo6pCdxXG9z9viPvzGjqPQN7A==",
+      "version": "10.61.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.61.0.tgz",
+      "integrity": "sha512-nct3VqOIuPBnsvqHHWkPG6Ta7QwJftxWXQzHt0+soNcWBoh5WU8hEzIPVEXzxTThJ9AOkF/df3ApWUX4i6ylqQ==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
-        "@sentry/core": "10.60.0",
-        "@sentry/node-core": "10.60.0",
-        "@sentry/opentelemetry": "10.60.0",
-        "@sentry/server-utils": "10.60.0",
+        "@sentry/core": "10.61.0",
+        "@sentry/node-core": "10.61.0",
+        "@sentry/opentelemetry": "10.61.0",
+        "@sentry/server-utils": "10.61.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -2713,14 +2713,14 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.60.0.tgz",
-      "integrity": "sha512-aXi9ixvP+hgUZPPZCRwMNHgY2I0gkSeoAKAUuysDJhWDmrygwfGdlkbGmmtW6PQjtMYFx69Igt5btvhjEBoJTw==",
+      "version": "10.61.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.61.0.tgz",
+      "integrity": "sha512-aVSnYqaq5FXv9hX6lVGbg4gB+mVrb6QDoNE/IBq8OBR90TR9I/KU6KlWAcfB9H7I6CHnedldOpljkMAJ5eZ3qA==",
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.12.0",
-        "@sentry/core": "10.60.0",
-        "@sentry/opentelemetry": "10.60.0",
+        "@sentry/core": "10.61.0",
+        "@sentry/opentelemetry": "10.61.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -2752,13 +2752,13 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.60.0.tgz",
-      "integrity": "sha512-gl+2NVH+9RmTu7pd9kV1tKif+Th+p9tmnXR1l3Sb3Wqo1ir5FaNMKrloWEKMXjnepii9EJUrEHdSC+i8NoexxQ==",
+      "version": "10.61.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.61.0.tgz",
+      "integrity": "sha512-wg8bY1sWPyFOVh59ThiFDeuyheD7DdQliqWmrCCa5q+PSRLij+zpmsGqjlzGU74lzj1Kvpkicw5LsO6U49b2xA==",
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.12.0",
-        "@sentry/core": "10.60.0"
+        "@sentry/core": "10.61.0"
       },
       "engines": {
         "node": ">=18"
@@ -2770,16 +2770,16 @@
       }
     },
     "node_modules/@sentry/server-utils": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.60.0.tgz",
-      "integrity": "sha512-SX+MzWM3nz5ttKT48rlfktm0ERyIpDLma+b6pYeWgW2oFHKcpIu0g0qMGJrZs4lKM3MlgV7IqLa4texMqTp9kQ==",
+      "version": "10.61.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.61.0.tgz",
+      "integrity": "sha512-IrOyMzlOyBkWtnVYb54sALf2f8WVqyyp7woRfHw8c3IMwUr5AskGOi7k2rjmUXO3Q0UkfHNVarexiEfo8ZqTsg==",
       "license": "MIT",
       "dependencies": {
         "@apm-js-collab/code-transformer": "^0.15.0",
         "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
         "@apm-js-collab/tracing-hooks": "^0.10.0",
         "@sentry/conventions": "^0.12.0",
-        "@sentry/core": "10.60.0",
+        "@sentry/core": "10.61.0",
         "magic-string": "~0.30.0"
       },
       "engines": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,7 +32,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1075.0",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
-    "@sentry/node": "^10.60.0",
+    "@sentry/node": "^10.61.0",
     "@workos-inc/node": "^8.13.0",
     "cors": "^2.8.5",
     "csv-stringify": "^6.8.0",


### PR DESCRIPTION
Daily Upgrade Scan auto-fix batch — backend, 2026-06-25.

## Bumps

| Package      | From    | To      | Notes                  |
| ------------ | ------- | ------- | ---------------------- |
| `@sentry/node` | 10.60.0 | 10.61.0 | Caret-range patch bump |

Lockfile + package.json only. No source changes.

## CVE references

No high/critical Dependabot alerts addressed (the GitHub default-branch security pane currently shows 4 moderate + 1 low — none reachable via routine `overrides`; all are transitive under `jest` and resolve when the deferred `jest` v30 bump lands).

## Quality gates (local)

- `npm run type-check` — clean
- `npm test` — 942 passed across 58 suites

## Diff guard

Only `backend/package.json` and `backend/package-lock.json` modified.

---
_Auto-opened by [Daily Upgrade Scan](https://github.com/deasystephen/bball-tracker/blob/main/docs/automation/daily-upgrade-scan.md) routine. Auto-merge enabled — will squash-merge once required CI checks pass._

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjVp1obzCjtNtSmtrpmVML)_