### PR TITLE
chore(deps): bump backend patch deps (2026-06-26)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/s3-request-presigner": "^3.1075.0",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
-        "@sentry/node": "^10.61.0",
+        "@sentry/node": "^10.62.0",
         "@workos-inc/node": "^8.13.0",
         "cors": "^2.8.5",
         "csv-stringify": "^6.8.0",
@@ -2684,28 +2684,28 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.61.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.61.0.tgz",
-      "integrity": "sha512-Edg8t2w45qEKiFnjeA6zRmU47R6la5FEMG+maZEOB2oTyJ+ujmh8LGaZ3G8aC0VdkKn8CXhHtDesze6oDc1oTA==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.62.0.tgz",
+      "integrity": "sha512-tV69fMg2sS5DUFmQSnS7Jd5qJAp0izxwcsvBVz2ieTM9VMRi99IfOSYW9UYr3p1yfuksk41kefN5PEbeedUE+A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.61.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.61.0.tgz",
-      "integrity": "sha512-nct3VqOIuPBnsvqHHWkPG6Ta7QwJftxWXQzHt0+soNcWBoh5WU8hEzIPVEXzxTThJ9AOkF/df3ApWUX4i6ylqQ==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.62.0.tgz",
+      "integrity": "sha512-4hoU67bJY0o3irEDMZu2UIztAOsvEqFkLXA7EUKl1LXMA3Ba1Lb32OUVqlsTypiEInSDs/BtM+aAFKojZ3P3Fw==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
-        "@sentry/core": "10.61.0",
-        "@sentry/node-core": "10.61.0",
-        "@sentry/opentelemetry": "10.61.0",
-        "@sentry/server-utils": "10.61.0",
+        "@sentry/core": "10.62.0",
+        "@sentry/node-core": "10.62.0",
+        "@sentry/opentelemetry": "10.62.0",
+        "@sentry/server-utils": "10.62.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -2713,14 +2713,14 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.61.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.61.0.tgz",
-      "integrity": "sha512-aVSnYqaq5FXv9hX6lVGbg4gB+mVrb6QDoNE/IBq8OBR90TR9I/KU6KlWAcfB9H7I6CHnedldOpljkMAJ5eZ3qA==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.62.0.tgz",
+      "integrity": "sha512-V7rDgbxViiHU0OpcFEDp3l41IFvWTasKHfXw8SQ6yIgtZ8VpFqmz2TR5N7X85iIOmWIvK5HV0yp0eDdsly0+rA==",
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.12.0",
-        "@sentry/core": "10.61.0",
-        "@sentry/opentelemetry": "10.61.0",
+        "@sentry/core": "10.62.0",
+        "@sentry/opentelemetry": "10.62.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -2752,13 +2752,13 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.61.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.61.0.tgz",
-      "integrity": "sha512-wg8bY1sWPyFOVh59ThiFDeuyheD7DdQliqWmrCCa5q+PSRLij+zpmsGqjlzGU74lzj1Kvpkicw5LsO6U49b2xA==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.62.0.tgz",
+      "integrity": "sha512-nFwBgtjfwgY8P5lAuQFWfAsQW1MXxuQ6kR/HtBs+A6julqwGGS2QnQ65OCWMzz6IqDEL/pRgT1405/gU+OXU3A==",
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.12.0",
-        "@sentry/core": "10.61.0"
+        "@sentry/core": "10.62.0"
       },
       "engines": {
         "node": ">=18"
@@ -2770,16 +2770,16 @@
       }
     },
     "node_modules/@sentry/server-utils": {
-      "version": "10.61.0",
-      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.61.0.tgz",
-      "integrity": "sha512-IrOyMzlOyBkWtnVYb54sALf2f8WVqyyp7woRfHw8c3IMwUr5AskGOi7k2rjmUXO3Q0UkfHNVarexiEfo8ZqTsg==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.62.0.tgz",
+      "integrity": "sha512-S5szsj6kKBhxw97b2HA98fYp/PpWXvSizlisEzb2rnL4IH6RAJ8wP05/fnth8pSywTH+gtUu+i6Wn8e8rX5HvA==",
       "license": "MIT",
       "dependencies": {
         "@apm-js-collab/code-transformer": "^0.15.0",
         "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
         "@apm-js-collab/tracing-hooks": "^0.10.0",
         "@sentry/conventions": "^0.12.0",
-        "@sentry/core": "10.61.0",
+        "@sentry/core": "10.62.0",
         "magic-string": "~0.30.0"
       },
       "engines": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,7 +32,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1075.0",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
-    "@sentry/node": "^10.61.0",
+    "@sentry/node": "^10.62.0",
     "@workos-inc/node": "^8.13.0",
     "cors": "^2.8.5",
     "csv-stringify": "^6.8.0",


### PR DESCRIPTION
Automated patch bumps within existing caret ranges. Daily upgrade scan 2026-06-26.

| Package | From | To |
| --- | --- | --- |
| `@sentry/node` | 10.61.0 | 10.62.0 |

No open Dependabot security alerts (high/critical) addressed in this batch.

**Quality gates**
- `npm run type-check` ✅
- `npm test` ✅ (942 tests passed, 58 suites)

**Diff guard**: only `backend/package.json` and `backend/package-lock.json` changed.

Auto-merge enabled — will squash once CI is green.


---
_Generated by [Claude Code](https://claude.ai/code/session_018L4C1C6MdasGqhatNm3wy4)_