### PR TITLE
chore(deps): bump mobile patch deps (2026-06-26)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mobile",
       "version": "1.0.0",
       "dependencies": {
-        "@amplitude/analytics-react-native": "^1.5.57",
+        "@amplitude/analytics-react-native": "^1.6.0",
         "@amplitude/analytics-types": "^2.11.1",
         "@expo-google-fonts/inter": "^0.4.2",
         "@expo-google-fonts/oswald": "^0.4.2",
@@ -34,7 +34,7 @@
         "expo-splash-screen": "^55.0.22",
         "expo-status-bar": "^55.0.6",
         "expo-updates": "^55.0.25",
-        "i18next": "^26.3.2",
+        "i18next": "^26.3.3",
         "lottie-react-native": "^7.3.8",
         "moti": "^0.30.0",
         "react": "^19.2.7",
@@ -90,9 +90,9 @@
       "license": "MIT"
     },
     "node_modules/@amplitude/analytics-core": {
-      "version": "2.50.0",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.50.0.tgz",
-      "integrity": "sha512-d8/U5aAHAs6XcpvQYpStxBxMxSwjDajZ0f6wMSwPCfxDGEWqcFaYuRKauh+vrn89D6gWcKi1VZ/tKCyhVby9sg==",
+      "version": "2.51.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.51.0.tgz",
+      "integrity": "sha512-09xlUQkZ8viMdbEh1LuL6Zz3NyktPtuFMh0/5qEjCPGkHXncAKak0pr1B4pmJyROaYUbZPybyv58RMqvdYnmmA==",
       "license": "MIT",
       "dependencies": {
         "@amplitude/analytics-connector": "^1.6.4",
@@ -103,12 +103,12 @@
       }
     },
     "node_modules/@amplitude/analytics-react-native": {
-      "version": "1.5.57",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.5.57.tgz",
-      "integrity": "sha512-JfydxAtEjtF19XUfUawFg7lvJlbYPQ89y48ScvpG1bFDOcYf1mHXwqxKedosBCjmZyqUL2poFXoFt8AFTqBcSA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.6.0.tgz",
+      "integrity": "sha512-nxPzp0tZu2EowFvyZ5DMnU8QxfH6tbSpv7vhbWYhVxMlKZTrk5sn9s12R/vVw9YasQb6oiQMbvUE5Wt66gEzAg==",
       "license": "MIT",
       "dependencies": {
-        "@amplitude/analytics-core": "2.50.0",
+        "@amplitude/analytics-core": "2.51.0",
         "@amplitude/ua-parser-js": "^0.7.31",
         "@react-native-async-storage/async-storage": "^1.17.11",
         "tslib": "^2.4.1"
@@ -13020,9 +13020,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.3.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.2.tgz",
-      "integrity": "sha512-QQkXAM1sPDHqhxMQuBeHVMUn6mJchF+wdpOoQerciLAFqO3ZYdxO0EUbeEhruyutnNwpUQIITDVzLjwnNL0T1w==",
+      "version": "26.3.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.3.tgz",
+      "integrity": "sha512-aYVegyBdXSO93CMMihvr47jI7GHSOcIahMpJX+qzUXDzW4xDJf2uenIA+45vDU+YhiVdcfsql70AC9RVdMNrHg==",
       "funding": [
         {
           "type": "individual",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,7 +15,7 @@
     "eas-build-on-success": "node scripts/sentry-upload-sourcemaps.js"
   },
   "dependencies": {
-    "@amplitude/analytics-react-native": "^1.5.57",
+    "@amplitude/analytics-react-native": "^1.6.0",
     "@amplitude/analytics-types": "^2.11.1",
     "@expo-google-fonts/inter": "^0.4.2",
     "@expo-google-fonts/oswald": "^0.4.2",
@@ -41,7 +41,7 @@
     "expo-splash-screen": "^55.0.22",
     "expo-status-bar": "^55.0.6",
     "expo-updates": "^55.0.25",
-    "i18next": "^26.3.2",
+    "i18next": "^26.3.3",
     "lottie-react-native": "^7.3.8",
     "moti": "^0.30.0",
     "react": "^19.2.7",


### PR DESCRIPTION
Automated patch bumps within existing caret ranges. Daily upgrade scan 2026-06-26.

| Package | From | To |
| --- | --- | --- |
| `@amplitude/analytics-react-native` | 1.5.57 | 1.6.0 |
| `i18next` | 26.3.2 | 26.3.3 |

No open Dependabot security alerts (high/critical) addressed in this batch.

**Quality gates**
- `npm run type-check` ✅
- `npm test` ✅ (446 tests passed, 45 suites)
- `npx expo export --platform ios` ✅

**Diff guard**: only `mobile/package.json` and `mobile/package-lock.json` changed.

Auto-merge enabled — will squash once CI is green.


---
_Generated by [Claude Code](https://claude.ai/code/session_018L4C1C6MdasGqhatNm3wy4)_