### PR TITLE
chore(deps): bump backend patch deps (2026-06-27)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -43,7 +43,7 @@
         "@types/pdfkit": "^0.17.6",
         "@types/pg": "^8.20.0",
         "@types/supertest": "^7.2.0",
-        "eslint": "^10.5.0",
+        "eslint": "^10.6.0",
         "globals": "^17.7.0",
         "jest": "^29.7.0",
         "socket.io-client": "^4.8.3",
@@ -4858,9 +4858,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/backend/package.json
+++ b/backend/package.json
@@ -74,7 +74,7 @@
     "@types/pdfkit": "^0.17.6",
     "@types/pg": "^8.20.0",
     "@types/supertest": "^7.2.0",
-    "eslint": "^10.5.0",
+    "eslint": "^10.6.0",
     "globals": "^17.7.0",
     "jest": "^29.7.0",
     "socket.io-client": "^4.8.3",


### PR DESCRIPTION
Daily Upgrade Scan — auto-fix bucket (backend).

Lockfile-only minor bump within existing caret range.

| Package | From   | To     | Range pinned in package.json |
| ------- | ------ | ------ | ---------------------------- |
| eslint  | 10.5.0 | 10.6.0 | `^10.6.0`                    |

**Gates run on this branch**
- `npm run type-check` — PASS
- `npm test` — 58 suites / 942 tests PASS
- Diff guard — only `backend/package.json` and `backend/package-lock.json` touched

**CVE alerts**: 5 Dependabot alerts on `main` (1 low, 4 moderate) reported on push. None are high/critical, so they don't fit the auto-fix CVE criteria; will surface in the daily log so they get triaged manually.

Auto-merge enabled — squash + delete-branch once required checks pass.

🤖 Generated by the Daily Upgrade Scan routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXH4Yt28qS9va8wLPpwyPc)_