### PR TITLE
chore(deps): bump mobile patch deps (2026-07-03)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -15,7 +15,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/datetimepicker": "^8.6.0",
-        "@sentry/react-native": "^8.17.0",
+        "@sentry/react-native": "^8.17.1",
         "@tanstack/react-query": "^5.101.2",
         "axios": "^1.18.1",
         "babel-preset-expo": "^55.0.23",
@@ -6494,9 +6494,9 @@
       }
     },
     "node_modules/@sentry/expo-upload-sourcemaps": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry/expo-upload-sourcemaps/-/expo-upload-sourcemaps-8.17.0.tgz",
-      "integrity": "sha512-WeW8tCBa4V2GZFQaZC43ziAk6/I85OJZXIsUacYj1yrjHbnEeihmI66RSyoGGdKY3SPmygwnvIcJuAQN0F4Ebw==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@sentry/expo-upload-sourcemaps/-/expo-upload-sourcemaps-8.17.1.tgz",
+      "integrity": "sha512-whzQnfATgqn6z5NK0/hZhYSp/9RnSMc3iad7ckck2zsozBiXUrNEQpi80UQZGsywvNkEhrRdV2HVeG5+TiwfqQ==",
       "license": "MIT",
       "dependencies": {
         "@sentry/cli": "3.6.0"
@@ -6580,16 +6580,16 @@
       }
     },
     "node_modules/@sentry/react-native": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.17.0.tgz",
-      "integrity": "sha512-UhoQAclPXhFCi6RlGkVSKsLiSQz5GECvcW3l9WJ7plqPrT8fRdl7zKnoPbSjkVTcxfNOQMlixqDaJnhePnsRSg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.17.1.tgz",
+      "integrity": "sha512-vp7dTN7MdSxHcFUg/w9/p8rj6xvwVoa/AgjX1ngimIG2eddkHeXQAxoC9j6gTjFAH5XiFYoqEgfIPqJem/j3Ug==",
       "license": "MIT",
       "dependencies": {
         "@sentry/babel-plugin-component-annotate": "5.3.0",
         "@sentry/browser": "10.63.0",
         "@sentry/cli": "3.6.0",
         "@sentry/core": "10.63.0",
-        "@sentry/expo-upload-sourcemaps": "8.17.0",
+        "@sentry/expo-upload-sourcemaps": "8.17.1",
         "@sentry/react": "10.63.0"
       },
       "bin": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -22,7 +22,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "^8.6.0",
-    "@sentry/react-native": "^8.17.0",
+    "@sentry/react-native": "^8.17.1",
     "@tanstack/react-query": "^5.101.2",
     "axios": "^1.18.1",
     "babel-preset-expo": "^55.0.23",


### PR DESCRIPTION
Daily Upgrade Scan — mobile auto-fix bucket (2026-07-03).

| Package | From | To |
| --- | --- | --- |
| `@sentry/react-native` | 8.17.0 | 8.17.1 |

Within existing caret range (lockfile-only patch bump).

**No open Dependabot alerts of high/critical severity** on mobile — nothing to override this run. (`npm audit`: 23 moderate, all transitive under the Expo / EAS families whose parent bumps are deferred to the next SDK upgrade.)

**Quality gates**
- ✅ `npm run type-check`
- ✅ `npm test` — 446 tests, 45 suites passing
- ✅ `npx expo export --platform ios` — bundle produced

Diff limited to `mobile/package.json` + `mobile/package-lock.json` (routine diff-guard satisfied).

Auto-merge enabled — will squash-merge once CI is green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K7Lp6dMEEhDgrEy4zowqoo)_