### PR TITLE
chore(deps): bump mobile patch deps (2026-07-08)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -34,7 +34,7 @@
         "expo-splash-screen": "^55.0.22",
         "expo-status-bar": "^55.0.6",
         "expo-updates": "^55.0.25",
-        "i18next": "^26.3.4",
+        "i18next": "^26.3.5",
         "lottie-react-native": "^7.3.8",
         "moti": "^0.30.0",
         "react": "^19.2.7",
@@ -13020,9 +13020,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.3.4",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.4.tgz",
-      "integrity": "sha512-pa7m0d7pBDqGHZxljT+WPFeyFgQ7P7SciPPo1tTqYuO0z4sqADYhwnBESmmGp/wEof1inwdls/k8ZgTg8rxFHA==",
+      "version": "26.3.5",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.5.tgz",
+      "integrity": "sha512-cd5lgkvjYQAPDfP3bbrAIE1wJmjTIlsrsjDqlvsHn4wFAerP5O0NfAe8RiDcXRfukN5ETe7Tlmfp6DkyuqDn6Q==",
       "funding": [
         {
           "type": "individual",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -41,7 +41,7 @@
     "expo-splash-screen": "^55.0.22",
     "expo-status-bar": "^55.0.6",
     "expo-updates": "^55.0.25",
-    "i18next": "^26.3.4",
+    "i18next": "^26.3.5",
     "lottie-react-native": "^7.3.8",
     "moti": "^0.30.0",
     "react": "^19.2.7",


### PR DESCRIPTION
Within-caret patch bumps discovered by `npm outdated` in `/mobile`.

| Package  | From    | To      |
|----------|---------|---------|
| i18next  | 26.3.4  | 26.3.5  |

`@sentry/react-native` 8.17.1 → 8.17.2 is already covered by open Dependabot PR #239, so it is excluded from this batch to avoid a conflict.

## Quality gates

- `npm run type-check` ✅
- `npm test` ✅ (45 suites, 446 tests passing)
- `npx expo export --platform ios` ✅

## Diff guard

Only `mobile/package.json` + `mobile/package-lock.json` touched.

---

Opened by the Daily Upgrade Scan routine. Auto-merge enabled.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYy8f6aF9JLGhMP4MwJta5)_