### PR TITLE
chore(deps): bump mobile patch deps (2026-07-10)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,14 +8,14 @@
       "name": "mobile",
       "version": "1.0.0",
       "dependencies": {
-        "@amplitude/analytics-react-native": "^1.6.1",
+        "@amplitude/analytics-react-native": "^1.6.2",
         "@amplitude/analytics-types": "^2.11.1",
         "@expo-google-fonts/inter": "^0.4.2",
         "@expo-google-fonts/oswald": "^0.4.2",
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/datetimepicker": "^8.6.0",
-        "@sentry/react-native": "^8.17.1",
+        "@sentry/react-native": "^8.18.0",
         "@tanstack/react-query": "^5.101.2",
         "axios": "^1.18.1",
         "babel-preset-expo": "^55.0.23",
@@ -84,15 +84,15 @@
       }
     },
     "node_modules/@amplitude/analytics-connector": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.6.4.tgz",
-      "integrity": "sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.6.5.tgz",
+      "integrity": "sha512-EcDT+E4vliT7WAeOCbyE4rNkTUdLMR9dGCETX+36U7gAROr8jARG6ObhW7TTWdoYDlUe25IllZnRKdXHRKlWJQ==",
       "license": "MIT"
     },
     "node_modules/@amplitude/analytics-core": {
-      "version": "2.52.0",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.52.0.tgz",
-      "integrity": "sha512-L1If4vznYDdZlcM1sY0BO2BvF9JpLe1G8OlUNttShDECgfVqHvyHlYPP0/Fa3GfW/MDl/xDZlo8loOLg8kGUpQ==",
+      "version": "2.52.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.52.1.tgz",
+      "integrity": "sha512-1gYgylvL/SODKuzKNLq3G5xhp5giEWap9OwWbBsCwlBgTmt9nk0TlmuuadJj80u9CwBDFLLpmHuHimD8nPnX2Q==",
       "license": "MIT",
       "dependencies": {
         "@amplitude/analytics-connector": "^1.6.4",
@@ -103,12 +103,12 @@
       }
     },
     "node_modules/@amplitude/analytics-react-native": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.6.1.tgz",
-      "integrity": "sha512-E2a4JLq7iXhtR/V6Jaby83EsWJKIp5n+qTrIqAg+7dhF5k8ES+Mp8BCg9WCx3hFAoPU0iq7eB2K9YDmRyE6qpQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.6.2.tgz",
+      "integrity": "sha512-WYaOByZb+Qxbccl3VFvse7ygQMgyc71CnmrWYAOUpZYZ/sFm3UHWnIAAEJK7UM8O6+9IQGItqzBlNFRhS6t7Aw==",
       "license": "MIT",
       "dependencies": {
-        "@amplitude/analytics-core": "2.52.0",
+        "@amplitude/analytics-core": "2.52.1",
         "@amplitude/ua-parser-js": "^0.7.31",
         "@react-native-async-storage/async-storage": "^1.17.11",
         "tslib": "^2.4.1"
@@ -6293,28 +6293,28 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.63.0.tgz",
-      "integrity": "sha512-0mi56YOkwgyjdLOcN5cB1//EcYzEOt3NZ2GLygE92B3zAAwVM1WgbmibZCXToKFClH7z1uH3VWVfBffmkwIMYw==",
+      "version": "10.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.64.0.tgz",
+      "integrity": "sha512-CHZ7+79evh8knBtVHjW/XqV3mRaWs2TdjX7i55zpFe9vcNngQHV++0ss8ird/xfMY1mfCDtbyAN+Z6XY2o5aJA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.63.0",
-        "@sentry/core": "10.63.0",
-        "@sentry/feedback": "10.63.0",
-        "@sentry/replay": "10.63.0",
-        "@sentry/replay-canvas": "10.63.0"
+        "@sentry/browser-utils": "10.64.0",
+        "@sentry/core": "10.64.0",
+        "@sentry/feedback": "10.64.0",
+        "@sentry/replay": "10.64.0",
+        "@sentry/replay-canvas": "10.64.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/browser-utils": {
-      "version": "10.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.63.0.tgz",
-      "integrity": "sha512-DhUGNN+CH8fzAs6qAsueKPU70qShyTX3NxLhIP+l5DbGXDSXpYXBT6s8ubZus0/LhxpLvI0iSyNIDvZRD/gZaA==",
+      "version": "10.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.64.0.tgz",
+      "integrity": "sha512-qXvUpsZdE0+6SovhDZvjN4JkqQEpzeYsrOF5g63wMsqJWWv2vW/pQZIlJs0F6C0t4q5AHZL4fl5rNkvpVqFdKA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.63.0"
+        "@sentry/core": "10.64.0"
       },
       "engines": {
         "node": ">=18"
@@ -6484,19 +6484,31 @@
         "node": ">=18"
       }
     },
-    "node_modules/@sentry/core": {
-      "version": "10.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.63.0.tgz",
-      "integrity": "sha512-OtUbsrnbEHffOF2S2+M5zXa3HIM0U2b4CDVLKMY1dgS0J3ivRF8XvkjvyIcEG/y8JXnwXbnprLyjhG+AqMdUZQ==",
+    "node_modules/@sentry/conventions": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
+      "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.64.0.tgz",
+      "integrity": "sha512-HjojJcXD1l2qZ1AXje2s0XY/nYsaUt00wsM1HMBImA8vAClyPisFE/CC0/UD6pEvsGFhVgi8Dcxo7EN41uyeFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.15.1"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/expo-upload-sourcemaps": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/@sentry/expo-upload-sourcemaps/-/expo-upload-sourcemaps-8.17.1.tgz",
-      "integrity": "sha512-whzQnfATgqn6z5NK0/hZhYSp/9RnSMc3iad7ckck2zsozBiXUrNEQpi80UQZGsywvNkEhrRdV2HVeG5+TiwfqQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/expo-upload-sourcemaps/-/expo-upload-sourcemaps-8.18.0.tgz",
+      "integrity": "sha512-yJCJcG+gdGhYL11E6B59Upt0Txxb1RHTJ9df2CqfukNS723KRzg+kESEhUKHz9BQzYmvE8vnRvqobA3xA4j7Yw==",
       "license": "MIT",
       "dependencies": {
         "@sentry/cli": "3.6.0"
@@ -6521,12 +6533,12 @@
       }
     },
     "node_modules/@sentry/feedback": {
-      "version": "10.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.63.0.tgz",
-      "integrity": "sha512-If/+72xFg9ylz4twUo3U9gUpZ+Ys+T/3Y09WH7r2gGhWEOF9bp+ta94+Pg7Lb0M2nVD7waz4OxIvB49GEvtLDA==",
+      "version": "10.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.64.0.tgz",
+      "integrity": "sha512-YrmKwRoAto+nwo26DoAhnpNmhkrVkuQFIAXqlTD8ipERjhcSNUYJAkAB+nH4w1KIgm9QQZE1sTq3iNQdPl1XMQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.63.0"
+        "@sentry/core": "10.64.0"
       },
       "engines": {
         "node": ">=18"
@@ -6564,13 +6576,13 @@
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.63.0.tgz",
-      "integrity": "sha512-+/Y0dd4EMqyqYBJ1D3bAYYuG+ccIx5+IFcbTZ9p+XWnW6nNIVjy5zttVftYo6xOmtTQbzRuPT/vO4dqDHKKmfw==",
+      "version": "10.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.64.0.tgz",
+      "integrity": "sha512-oShEKcosBKdm0kgan8suFb6Jj8poccEyDz2qiflonq/5/hUDyzdVeKfFzf0b1MmdjWSn9k3hfrLNFfPNCuEt7Q==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.63.0",
-        "@sentry/core": "10.63.0"
+        "@sentry/browser": "10.64.0",
+        "@sentry/core": "10.64.0"
       },
       "engines": {
         "node": ">=18"
@@ -6580,17 +6592,17 @@
       }
     },
     "node_modules/@sentry/react-native": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.17.1.tgz",
-      "integrity": "sha512-vp7dTN7MdSxHcFUg/w9/p8rj6xvwVoa/AgjX1ngimIG2eddkHeXQAxoC9j6gTjFAH5XiFYoqEgfIPqJem/j3Ug==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.18.0.tgz",
+      "integrity": "sha512-W9jrTort+0LEkcezXRpIRMUaWXxbgvzEXlsuvCRU14n7yQiTfzKgFeSACpkzgqoW4iqJKphXoI9l4AVb54AdZg==",
       "license": "MIT",
       "dependencies": {
         "@sentry/babel-plugin-component-annotate": "5.3.0",
-        "@sentry/browser": "10.63.0",
+        "@sentry/browser": "10.64.0",
         "@sentry/cli": "3.6.0",
-        "@sentry/core": "10.63.0",
-        "@sentry/expo-upload-sourcemaps": "8.17.1",
-        "@sentry/react": "10.63.0"
+        "@sentry/core": "10.64.0",
+        "@sentry/expo-upload-sourcemaps": "8.18.0",
+        "@sentry/react": "10.64.0"
       },
       "bin": {
         "sentry-eas-build-on-complete": "scripts/eas-build-hook.js",
@@ -6610,26 +6622,26 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "10.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.63.0.tgz",
-      "integrity": "sha512-u4fDaLbd4QmJbU0qGzV5g2B2hjw5utdeZzpTrmq565AS5o6mfaZdCz30zF9R2Unkn0g9SJr90piTN2RMwvDrkw==",
+      "version": "10.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.64.0.tgz",
+      "integrity": "sha512-q8nke2GDSwEiu1zYoctDDvnSNTjHWoVAKo2JXTleD0nwOO6IlAgUYmsm3qEQiSW7BVla9W1TRbW6ChFAUXYZbw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.63.0",
-        "@sentry/core": "10.63.0"
+        "@sentry/browser-utils": "10.64.0",
+        "@sentry/core": "10.64.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/replay-canvas": {
-      "version": "10.63.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.63.0.tgz",
-      "integrity": "sha512-1Dg6yo+KDNZcE9M6V2EP4DGgTDJMcUgg5ui69w/E96ZZPWErS/bibK2bGj20H3qwpJXlnEwXB5YAJ2fZ620T1A==",
+      "version": "10.64.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.64.0.tgz",
+      "integrity": "sha512-EioBwcnnhtPiXzTZJTbZKaMEg3qNM5YZlX1VanoXomPATqfJD62cb/M27zhgiWXXJ7e8/NGVHvwNDYGrqsN39g==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.63.0",
-        "@sentry/replay": "10.63.0"
+        "@sentry/core": "10.64.0",
+        "@sentry/replay": "10.64.0"
       },
       "engines": {
         "node": ">=18"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,14 +15,14 @@
     "eas-build-on-success": "node scripts/sentry-upload-sourcemaps.js"
   },
   "dependencies": {
-    "@amplitude/analytics-react-native": "^1.6.1",
+    "@amplitude/analytics-react-native": "^1.6.2",
     "@amplitude/analytics-types": "^2.11.1",
     "@expo-google-fonts/inter": "^0.4.2",
     "@expo-google-fonts/oswald": "^0.4.2",
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "^8.6.0",
-    "@sentry/react-native": "^8.17.1",
+    "@sentry/react-native": "^8.18.0",
     "@tanstack/react-query": "^5.101.2",
     "axios": "^1.18.1",
     "babel-preset-expo": "^55.0.23",


### PR DESCRIPTION
Daily Upgrade Scan — auto-fix bucket for mobile.

Lockfile + package.json bumps of caret-range patches surfaced by `npm outdated`.

| Package                            | From    | To      |
| ---------------------------------- | ------- | ------- |
| @amplitude/analytics-react-native  | 1.6.1   | 1.6.2   |
| @sentry/react-native               | 8.17.1  | 8.18.0  |

The `@sentry/react-native` bump supersedes Dependabot PR #239 (8.17.1 → 8.17.2); once this merges, that PR can be closed.

### Security
No open Dependabot alerts of high/critical severity in mobile today. `npm audit` reports 23 moderate transitive advisories in the Expo / `eas-cli` chain (`joi`, `js-yaml`, `uuid`, `yaml`, `ajv`, `ts-deepmerge`). All require a semver-major Expo SDK / eas-cli bump to clear and are tracked in the deferral list (#77).

### Quality gates
- `npm run type-check` ✅
- `npm test` ✅ — 45 suites / 446 tests passing
- `npx expo export --platform ios --output-dir /tmp/v` ✅ — ios bundle 8.4MB

### Diff guard
`git diff --name-only` on the batch: only `mobile/package.json` + `mobile/package-lock.json`.

Opened by the Daily Upgrade Scan routine. See docs/automation/daily-upgrade-scan.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJECtAwx3Vq9yxvLJ5TfKJ)_