### PR TITLE
chore(deps): bump backend patch deps (2026-07-12)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,7 +22,7 @@
         "expo-server-sdk": "^6.1.0",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
-        "helmet": "^8.2.0",
+        "helmet": "^8.3.0",
         "ics": "^3.12.0",
         "ioredis": "^5.11.1",
         "kafkajs": "^2.2.4",
@@ -5666,9 +5666,9 @@
       }
     },
     "node_modules/helmet": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
-      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,7 +40,7 @@
     "expo-server-sdk": "^6.1.0",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",
-    "helmet": "^8.2.0",
+    "helmet": "^8.3.0",
     "ics": "^3.12.0",
     "ioredis": "^5.11.1",
     "kafkajs": "^2.2.4",


### PR DESCRIPTION
Automated daily-upgrade scan (2026-07-12).

| package | from  | to    | notes                       |
| ------- | ----- | ----- | --------------------------- |
| helmet  | 8.2.0 | 8.3.0 | minor within `^8.2.0` caret |

## Quality gates
- `backend/`: `npm run type-check` ✅
- `backend/`: `npm test` ✅ (58 suites, 942 tests)

## CVE refs
None — this scan turned up no open Dependabot alerts of severity high/critical. Repo push message reports 5 default-branch alerts (4 moderate, 1 low); none required overrides.

## Diff guard
Touches only `backend/package.json` and `backend/package-lock.json`.

---
_Auto-merge enabled. Generated by the Daily Upgrade Scan routine — see [`docs/automation/daily-upgrade-scan.md`](../blob/main/docs/automation/daily-upgrade-scan.md)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATADhgH7vFfVrgCXyVntq9)_