### PR TITLE
chore(deps): bump backend patch deps (2026-07-17)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1088.0",
-        "@aws-sdk/client-sesv2": "^3.1088.0",
-        "@aws-sdk/s3-request-presigner": "^3.1088.0",
+        "@aws-sdk/client-s3": "^3.1089.0",
+        "@aws-sdk/client-sesv2": "^3.1089.0",
+        "@aws-sdk/s3-request-presigner": "^3.1089.0",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "@sentry/node": "^10.66.0",
@@ -21,7 +21,7 @@
         "dotenv": "^17.4.2",
         "expo-server-sdk": "^6.1.0",
         "express": "^5.2.1",
-        "express-rate-limit": "^8.5.2",
+        "express-rate-limit": "^8.6.0",
         "helmet": "^8.3.0",
         "ics": "^3.12.0",
         "ioredis": "^5.11.1",
@@ -49,7 +49,7 @@
         "socket.io-client": "^4.8.3",
         "supertest": "^7.1.3",
         "ts-jest": "^29.4.11",
-        "tsx": "^4.23.0",
+        "tsx": "^4.23.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.64.0"
       }
@@ -114,14 +114,14 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1088.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1088.0.tgz",
-      "integrity": "sha512-9ryKKxnjtJRKLDI24P+2gQZki7k28BeV6gz1AySvFDWayhjAZuh4QZjCyx55tqR8Oz0IJxWutgJRO43dDOcXoQ==",
+      "version": "3.1089.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1089.0.tgz",
+      "integrity": "sha512-Sc+JOtNeP+v+XdP9Rb4Hh+uhiNO2hh/CZQbKYooNakhOIgK6/K0cjoDCEGeFmkG0vf2DopTmSctzKlcKwy1BPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/checksums": "^3.1000.18",
         "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-node": "^3.972.69",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
         "@aws-sdk/middleware-sdk-s3": "^3.972.64",
         "@aws-sdk/signature-v4-multi-region": "^3.996.41",
         "@aws-sdk/types": "^3.974.2",
@@ -136,13 +136,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sesv2": {
-      "version": "3.1088.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1088.0.tgz",
-      "integrity": "sha512-cYDQPqJ+AfOIF7uLIITsmdeYyRCcyEf7bfPuuq4tNBuwGOGYcTZSVOv6sf+XuH2x0KkQNmqHuxfljG9CQs5dxg==",
+      "version": "3.1089.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1089.0.tgz",
+      "integrity": "sha512-g7QQ63YawmZKLfvs0UO3YfQCRG2K6rE8bQXcRsZkzPgBBhSD/H5Qx6iNQgEzkCBPUXJaDrN4e0OuG3C0ML47tA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-node": "^3.972.69",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
         "@aws-sdk/signature-v4-multi-region": "^3.996.41",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.4",
@@ -209,15 +209,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.3.tgz",
-      "integrity": "sha512-WpuqYX4gGkx++fCTSWE8+41JzkZVcrI50SH48Ml4CsG1pyuHKyMmpw/FixBHDrmjoQ553PmeCLa/fZIcst+WyA==",
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
+      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.3",
         "@aws-sdk/credential-provider-env": "^3.972.59",
         "@aws-sdk/credential-provider-http": "^3.972.61",
-        "@aws-sdk/credential-provider-login": "^3.972.65",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
         "@aws-sdk/credential-provider-process": "^3.972.59",
         "@aws-sdk/credential-provider-sso": "^3.973.3",
         "@aws-sdk/credential-provider-web-identity": "^3.972.65",
@@ -233,9 +233,9 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.65.tgz",
-      "integrity": "sha512-xr9rgjYEdmC2Tpg2lwt9o+nOEaK9Qpd+dBjzrVCuWWyQfvhO91Ezu0Hh9ts2VUxOZxmS/k5T9msa34e4R1bnrQ==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
+      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.3",
@@ -250,14 +250,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.69.tgz",
-      "integrity": "sha512-wbJGGesd0Tl18bmUcbj1xJ+e7CpuRJ6PIpMywLFuUttGy615lua87cJ0EA8pFpY/QgPuUXbnupWBtSPJ9tyZhg==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
+      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "^3.972.59",
         "@aws-sdk/credential-provider-http": "^3.972.61",
-        "@aws-sdk/credential-provider-ini": "^3.973.3",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
         "@aws-sdk/credential-provider-process": "^3.972.59",
         "@aws-sdk/credential-provider-sso": "^3.973.3",
         "@aws-sdk/credential-provider-web-identity": "^3.972.65",
@@ -359,9 +359,9 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1088.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1088.0.tgz",
-      "integrity": "sha512-NEv9O5q+IrsDNKPmNhTlZ3hjtomgfL1OEJRCmDSF06dbmZ6IUJfrLQTLO7LWbM4sxvYui1LRAFCdO2TM3Hdq4A==",
+      "version": "3.1089.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1089.0.tgz",
+      "integrity": "sha512-NYLT340eRdqv8XIUEIEWcIYICDxBGxpgdyQ9veBkW5XxlRDNn19IZ8b46ddec+HBQea/18W+/IfogCqbac3CGQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.3",
@@ -2711,9 +2711,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.4.tgz",
-      "integrity": "sha512-G1GRglAabzEhqghJMBAd54FkRS7SAFGHEwbhcI9r+O+LIMuFsLyXkLZkCoFSgAglRu8s/URVXJB0hglq3ZipIg==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
+      "integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -2724,12 +2724,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.9.tgz",
-      "integrity": "sha512-2nfV4qRKiYeXU4zD2vvSCfg5dfp/BuhrM73vt7q9gzBhxs4rbPxXY21wo+kyI3bRmXcEGRnCLTaW8O437jzHIg==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.10.tgz",
+      "integrity": "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.5",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -5033,11 +5033,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -8732,9 +8733,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,9 +27,9 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1088.0",
-    "@aws-sdk/client-sesv2": "^3.1088.0",
-    "@aws-sdk/s3-request-presigner": "^3.1088.0",
+    "@aws-sdk/client-s3": "^3.1089.0",
+    "@aws-sdk/client-sesv2": "^3.1089.0",
+    "@aws-sdk/s3-request-presigner": "^3.1089.0",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@sentry/node": "^10.66.0",
@@ -39,7 +39,7 @@
     "dotenv": "^17.4.2",
     "expo-server-sdk": "^6.1.0",
     "express": "^5.2.1",
-    "express-rate-limit": "^8.5.2",
+    "express-rate-limit": "^8.6.0",
     "helmet": "^8.3.0",
     "ics": "^3.12.0",
     "ioredis": "^5.11.1",
@@ -80,7 +80,7 @@
     "socket.io-client": "^4.8.3",
     "supertest": "^7.1.3",
     "ts-jest": "^29.4.11",
-    "tsx": "^4.23.0",
+    "tsx": "^4.23.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.64.0"
   }


### PR DESCRIPTION
Batched patch/minor bumps produced by the Daily Upgrade Scan routine — all stay within existing caret ranges (lockfile-only) or match caret-permitted minor bumps.

## Bumps

| Package | From | To |
| --- | --- | --- |
| `@aws-sdk/client-s3` | 3.1088.0 | 3.1089.0 |
| `@aws-sdk/client-sesv2` | 3.1088.0 | 3.1089.0 |
| `@aws-sdk/s3-request-presigner` | 3.1088.0 | 3.1089.0 |
| `express-rate-limit` | 8.5.2 | 8.6.0 |
| `tsx` | 4.23.0 | 4.23.1 |

## CVE / security context

No **high/critical** Dependabot alerts open on the default branch. `npm audit` on backend shows only 1 low (`@babel/core` transitive) and 1 moderate (`js-yaml` transitive) — neither is inside the AUTO-FIX severity bracket (high/critical) so they are not touched by this batch. See the Daily upgrade scan log (#78) for the daily rollup.

## Quality gates

- `npm run type-check` — clean
- `npm test` — 58 suites / **942 tests** pass

## Diff guard

Only `backend/package.json` and `backend/package-lock.json` changed.

## Related

- Supersedes Dependabot PR #251 (`tsx` 4.23.0 → 4.23.1) — the batch includes the same bump; #251 can close automatically once this merges.
- Daily upgrade scan log: #78
- Deferred tracking issue: #77

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcwAPQTzvaTowTDaPdWgRy)_