### PR TITLE
chore(deps): bump mobile patch deps (2026-07-22)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mobile",
       "version": "1.0.0",
       "dependencies": {
-        "@amplitude/analytics-react-native": "^1.6.6",
+        "@amplitude/analytics-react-native": "^1.6.7",
         "@amplitude/analytics-types": "^2.11.1",
         "@expo-google-fonts/inter": "^0.4.2",
         "@expo-google-fonts/oswald": "^0.4.2",
@@ -37,8 +37,8 @@
         "i18next": "^26.3.6",
         "lottie-react-native": "^7.3.8",
         "moti": "^0.30.0",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "react-i18next": "^17.0.10",
         "react-native": "0.83.4",
         "react-native-confetti-cannon": "^1.5.2",
@@ -63,7 +63,7 @@
         "globals": "^17.7.0",
         "jest": "^29.7.0",
         "jest-expo": "^55.0.20",
-        "react-test-renderer": "^19.2.7",
+        "react-test-renderer": "^19.2.8",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.65.0"
       }
@@ -90,9 +90,9 @@
       "license": "MIT"
     },
     "node_modules/@amplitude/analytics-core": {
-      "version": "2.53.2",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.53.2.tgz",
-      "integrity": "sha512-TsmYeJ0ZcAURkQWqDNi5Ar25MH0KcQ64zdxYWn1N9BN2xaakOevz0/WwNVvthmf1gd/Bz9OZdaq4D5iqYd4Dow==",
+      "version": "2.54.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.54.0.tgz",
+      "integrity": "sha512-xZEpG5IQvRA6qBTnG+chANEeATL9oqOvQUrqKbwl+q0gX9a6skplUMBwhEhBv2iwuDAJhDF2+G2mYf7XGuEX4Q==",
       "license": "MIT",
       "dependencies": {
         "@amplitude/analytics-connector": "^1.6.4",
@@ -103,12 +103,13 @@
       }
     },
     "node_modules/@amplitude/analytics-react-native": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.6.6.tgz",
-      "integrity": "sha512-8dip2HPLtFyEI8oCT6wbcEFzfzV6XO/ptgbjOddXRxy/gWF2d2tMFqmGkzvmA4AFqn0Xl8/P501McScniyWJ4g==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.6.7.tgz",
+      "integrity": "sha512-1cYl11WVSUDxj0u6owAbyvby5m46HnYzhclUVuIfIrd/Pnhe958OSgsWBMphHtIv1QI0SB9OCx3DPfYKXvbUHw==",
       "license": "MIT",
       "dependencies": {
-        "@amplitude/analytics-core": "2.53.2",
+        "@amplitude/analytics-core": "2.54.0",
+        "@amplitude/plugin-network-capture-browser": "1.10.11",
         "@amplitude/ua-parser-js": "^0.7.31",
         "@react-native-async-storage/async-storage": "^1.17.11",
         "tslib": "^2.4.1"
@@ -123,6 +124,16 @@
       "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.11.1.tgz",
       "integrity": "sha512-wFEgb0t99ly2uJKm5oZ28Lti0Kh5RecR5XBkwfUpDzn84IoCIZ8GJTsMw/nThu8FZFc7xFDA4UAt76zhZKrs9A==",
       "license": "MIT"
+    },
+    "node_modules/@amplitude/plugin-network-capture-browser": {
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-network-capture-browser/-/plugin-network-capture-browser-1.10.11.tgz",
+      "integrity": "sha512-CbqUWu1fiGow6aCdMY1V/ybOan+39LJKfmnh5paZYQTsjTo5UUYGG6dzncuTqHlyx80nWQTt8UbaCux7g22vHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "2.54.0",
+        "tslib": "^2.4.1"
+      }
     },
     "node_modules/@amplitude/ua-parser-js": {
       "version": "0.7.33",
@@ -18197,9 +18208,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -18216,15 +18227,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-fast-compare": {
@@ -18273,9 +18284,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "license": "MIT"
     },
     "node_modules/react-is-18": {
@@ -18794,17 +18805,17 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.7.tgz",
-      "integrity": "sha512-U4TyPDJ9MsC8rFimXuJum8w40aPc9kbOZYO8Pc2/4A884i8hwJsMNA/JNyuOc/f2/37wHvk7HjpVl1V4re7Dig==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.8.tgz",
+      "integrity": "sha512-GHKPaDRaNYU24PHTLG8Bx8VMY9t+qNfxQbt/Yjp7aMWBkKU6766SR0n6TnYu7P5I1MfEuAMUadqiyDHyI4Yy9Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "react-is": "^19.2.7",
+        "react-is": "^19.2.8",
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/redent": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,7 +15,7 @@
     "eas-build-on-success": "node scripts/sentry-upload-sourcemaps.js"
   },
   "dependencies": {
-    "@amplitude/analytics-react-native": "^1.6.6",
+    "@amplitude/analytics-react-native": "^1.6.7",
     "@amplitude/analytics-types": "^2.11.1",
     "@expo-google-fonts/inter": "^0.4.2",
     "@expo-google-fonts/oswald": "^0.4.2",
@@ -44,8 +44,8 @@
     "i18next": "^26.3.6",
     "lottie-react-native": "^7.3.8",
     "moti": "^0.30.0",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "react-i18next": "^17.0.10",
     "react-native": "0.83.4",
     "react-native-confetti-cannon": "^1.5.2",
@@ -70,7 +70,7 @@
     "globals": "^17.7.0",
     "jest": "^29.7.0",
     "jest-expo": "^55.0.20",
-    "react-test-renderer": "^19.2.7",
+    "react-test-renderer": "^19.2.8",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0"
   },


### PR DESCRIPTION
Daily Upgrade Scan auto-fix — mobile patch bumps within existing caret ranges (lockfile + package.json only).

| Package                                | From    | To      |
|----------------------------------------|---------|---------|
| `@amplitude/analytics-react-native`    | 1.6.6   | 1.6.7   |
| `react`                                | 19.2.7  | 19.2.8  |
| `react-dom`                            | 19.2.7  | 19.2.8  |
| `react-test-renderer`                  | 19.2.7  | 19.2.8  |

**CVE / high-severity advisories fixed via overrides:** none this scan.

**Gates**
- `npm run type-check`: PASS
- `npm test`: PASS (45 suites, 446 tests)
- `npx expo export --platform ios`: PASS
- Diff guard: only `mobile/package.json` + `mobile/package-lock.json`

**Skipped this batch**
- `@tanstack/react-query` 5.101.2 → 5.101.4 — open Dependabot PR #262 already bumps to 5.101.3; next scan will pick up the remaining delta.

Auto-merge enabled after `@claude review once`. See [daily upgrade scan log](https://github.com/deasystephen/bball-tracker/issues/78).

---
_Generated by [Claude Code](https://claude.ai/code/session_01F98bcB3yikkkdxmbwxMroG)_