### PR TITLE
chore(deps): bump backend patch deps (2026-07-23)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1092.0",
-        "@aws-sdk/client-sesv2": "^3.1092.0",
-        "@aws-sdk/s3-request-presigner": "^3.1092.0",
+        "@aws-sdk/client-s3": "^3.1093.0",
+        "@aws-sdk/client-sesv2": "^3.1093.0",
+        "@aws-sdk/s3-request-presigner": "^3.1093.0",
         "@prisma/adapter-pg": "^7.9.0",
         "@prisma/client": "^7.9.0",
         "@sentry/node": "^10.66.0",
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1092.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1092.0.tgz",
-      "integrity": "sha512-NfcptdANQM1IgUT8QITKBN+PZPjshm5FyLKKjotEwscsDQGik4iDdLgwFYJSTlGoREv26Tf97WHpL7IZ3HF9nA==",
+      "version": "3.1093.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1093.0.tgz",
+      "integrity": "sha512-7452vEdp/nihIBWijnmcTBujXEFfbs4F02wyBDGqmNr6pwyo5GmQorx0zQIVg8QGFLXiBvsWKXBhCdiBcxNnGA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/checksums": "^3.1000.19",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sesv2": {
-      "version": "3.1092.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1092.0.tgz",
-      "integrity": "sha512-V+xc9Zkvh1W6wPvfkQIU3h2LFOuIpNIUIh5sB7YbyVe7Bmn/Lr6uDTYG/TIuzUOmlhaJz1LEtoVsmrfj6PyFtg==",
+      "version": "3.1093.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1093.0.tgz",
+      "integrity": "sha512-Lv39fmVecZiZvu92AHAZOC/BmubCoLlXTr7WUDv8cn2QYerkmhf5RV4m57NUj1K3yw1xKm7fleWm5odHE8rEMA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.976.0",
@@ -359,9 +359,9 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1092.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1092.0.tgz",
-      "integrity": "sha512-MF5u0f7NgLz3YusDAkYkFlTEEO1dutvAMDlE460vLxRBiln2Roo/IYfwHW+FNwE8Ys3dxiIPwTP3CfMz9a6Q0A==",
+      "version": "3.1093.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1093.0.tgz",
+      "integrity": "sha512-yEqbZRxq+ZkzrEr2oArnt9YZkdKW2SoZW4v4qpCAgOlxs6YJSRdJx3lOLaRwO3jsXfuVgohvm6Bt9MD4qATilg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.976.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,9 +27,9 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1092.0",
-    "@aws-sdk/client-sesv2": "^3.1092.0",
-    "@aws-sdk/s3-request-presigner": "^3.1092.0",
+    "@aws-sdk/client-s3": "^3.1093.0",
+    "@aws-sdk/client-sesv2": "^3.1093.0",
+    "@aws-sdk/s3-request-presigner": "^3.1093.0",
     "@prisma/adapter-pg": "^7.9.0",
     "@prisma/client": "^7.9.0",
     "@sentry/node": "^10.66.0",


### PR DESCRIPTION
Batched backend patch bumps produced by the Daily Upgrade Scan routine.

## Bumps (caret in-range, lockfile + range refresh)

| Package                           | From      | To        |
| --------------------------------- | --------- | --------- |
| `@aws-sdk/client-s3`              | 3.1092.0  | 3.1093.0  |
| `@aws-sdk/client-sesv2`           | 3.1092.0  | 3.1093.0  |
| `@aws-sdk/s3-request-presigner`   | 3.1092.0  | 3.1093.0  |

Skipped `@sentry/node` 10.66 → 10.67 — already covered by open Dependabot PR #263.

## Quality gates

- `npm run type-check` (after `prisma:generate`): OK
- `npm test`: **942/942** passing (58 suites)
- Diff guard: only `backend/package.json` + `backend/package-lock.json`

## CVE references

No CVEs pinned — the routine could not enumerate the repo's Dependabot alerts (no API access for alerts in this session). GitHub's push warning reports 4 high + 2 moderate alerts on `main`; those are surfaced in the daily log so a maintainer can review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cd4rtY6MYxNMWszw1qMrUW)_