### PR TITLE
chore(deps): bump mobile patch deps (2026-07-27)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -60,7 +60,7 @@
         "eas-cli": "^18.13.1",
         "eslint": "^9.39.5",
         "eslint-config-expo": "^56.0.4",
-        "globals": "^17.7.0",
+        "globals": "^17.8.0",
         "jest": "^29.7.0",
         "jest-expo": "^55.0.20",
         "react-test-renderer": "^19.2.8",
@@ -12941,9 +12941,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -67,7 +67,7 @@
     "eas-cli": "^18.13.1",
     "eslint": "^9.39.5",
     "eslint-config-expo": "^56.0.4",
-    "globals": "^17.7.0",
+    "globals": "^17.8.0",
     "jest": "^29.7.0",
     "jest-expo": "^55.0.20",
     "react-test-renderer": "^19.2.8",


### PR DESCRIPTION
Daily Upgrade Scan — mobile patch bump batch.

## Version table

| package   | from    | to      |
|-----------|---------|---------|
| `globals` | 17.7.0  | 17.8.0  |

Single in-caret dev-dep patch bump. No dependabot CVE alerts land in this batch. Other outdated mobile packages are either DEFER (RN/Expo ecosystem, major bumps) or already covered by open Dependabot PRs (`@tanstack/react-query` in #262, `tar` in #267).

## Quality gates

- `npm run type-check` — ✓
- `npm test` — ✓ 446 tests / 45 suites
- `npx expo export --platform ios --output-dir /tmp/v` — ✓ bundled (8.5MB hbc)
- Diff guard — ✓ only `mobile/package.json` + `mobile/package-lock.json`

Auto-merge enabled.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUktvaWac9BZ5BsvywBeHU)_