### PR TITLE
chore(deps): bump backend AWS SDK patch deps (2026-07-29)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1096.0",
-        "@aws-sdk/client-sesv2": "^3.1096.0",
-        "@aws-sdk/s3-request-presigner": "^3.1096.0",
+        "@aws-sdk/client-s3": "^3.1097.0",
+        "@aws-sdk/client-sesv2": "^3.1097.0",
+        "@aws-sdk/s3-request-presigner": "^3.1097.0",
         "@prisma/adapter-pg": "^7.9.1",
         "@prisma/client": "^7.9.1",
         "@sentry/node": "^10.66.0",
@@ -98,12 +98,12 @@
       }
     },
     "node_modules/@aws-sdk/checksums": {
-      "version": "3.1000.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.21.tgz",
-      "integrity": "sha512-AcYTunavv8dqm9u2pbq/gIlFERUo+jQDKKLZpYOgMLLytoAJ/qoyuhWj97FB7UzpMFVJNzMEUylzKK/s/05org==",
+      "version": "3.1000.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.22.tgz",
+      "integrity": "sha512-YsSac72lcCOSjk5X4fMc20SjltkGUDjckB2vYZcEd/RpgB+huzeQwVZrOWxUvLVo+5D7X9sURgmAAPmErgCQ7w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/core": "^3.977.2",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
@@ -114,15 +114,15 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1096.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1096.0.tgz",
-      "integrity": "sha512-sEx7KAEtkp1UqOoWQv2baM1rreClZG7o9YE8EfPvYpPBvGad1fQRG3sMHrOPMkIdZ9VjGRl25GiaG1MSeie2Mw==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1097.0.tgz",
+      "integrity": "sha512-iCBD95hrynpxiOzD301pUW9H3mxKcEfMErLqdg58WcIZnEqJuOd7JwcARsV3/y6OWj1t6j2tpS9lGt6X4OnPFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/checksums": "^3.1000.21",
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/credential-provider-node": "^3.972.73",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.67",
+        "@aws-sdk/checksums": "^3.1000.22",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.68",
         "@aws-sdk/signature-v4-multi-region": "^3.996.42",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
@@ -136,13 +136,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sesv2": {
-      "version": "3.1096.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1096.0.tgz",
-      "integrity": "sha512-IBuhAfFnlnZPpDLr3IPmKIZCdTmj/ayw+u+aWCew72t6k+IABDbPMfHbKxu3lmiVAjXXDxWpScsosO5clubbFw==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1097.0.tgz",
+      "integrity": "sha512-H5bOKCwq9IKgm4zgeY5430co848OgnRK0yEyCW+uD4cPVonryl/DK3hW/CG5IpIvR4bXhOhTAy668FjHTuO5MQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/credential-provider-node": "^3.972.73",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
         "@aws-sdk/signature-v4-multi-region": "^3.996.42",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
-      "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
+      "version": "3.977.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.2.tgz",
+      "integrity": "sha512-8sT/M5vDcagx5/iM0Bfx7f6i3mfVOQkA34+GTMwp0lIWZb6ma+bjkzDS/r9yqU2yTPBqqMBFPT3+d9kUuuNDJA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
@@ -175,12 +175,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.62",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.62.tgz",
-      "integrity": "sha512-BkDrk2cNjed31IKin/Oksb2ziF+gfuyRskFVuT4EU9Mep7M8Y/d8DJG4+anHme4Vuse7CwaEscwEfGyR6mzBhQ==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.63.tgz",
+      "integrity": "sha512-VSS9dftt7r7GiZ4gs8z0PNaMLVAaSj/MXVr6WQBtsrQQB9miJo7I6lQuJND1/ugFwK9x7OHCYZDkLSYh0FIZtA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/core": "^3.977.2",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
@@ -191,12 +191,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.64.tgz",
-      "integrity": "sha512-Wj1FGK2IxY5EccQCvH+niTYhIvDoDujJf2CpRRgS3NpYNEgiFNVItNbJYQjINRlu7fG7jSsXkKV0UWKriEplrw==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.65.tgz",
+      "integrity": "sha512-SH/ec7p1J0CfC28+ypH38IwGENd7tQEvTpmuRSlinthiGxKlwzJbXGXxIMAhn0/lpxnIxudNmCsw3Cy0PDRoAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/core": "^3.977.2",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/fetch-http-handler": "^5.6.10",
@@ -209,19 +209,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.7.tgz",
-      "integrity": "sha512-2CefB8cCxDu52P24B8Ay93/cTT199bcSvNHQ8e2f4BjSCF83yErBnTIZEBo0VeIgCfmw+PJKFUXnlQWxm2dkug==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.8.tgz",
+      "integrity": "sha512-alkQpDUHsjHGVXvlV0XFXpPfh9+aTMmN6UYRky0Qky8SbvdxoQdDHftT4uugq8XShP6WtDQW7bo5YQ0SfNSxRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/credential-provider-env": "^3.972.62",
-        "@aws-sdk/credential-provider-http": "^3.972.64",
-        "@aws-sdk/credential-provider-login": "^3.972.69",
-        "@aws-sdk/credential-provider-process": "^3.972.62",
-        "@aws-sdk/credential-provider-sso": "^3.973.6",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.68",
-        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-login": "^3.972.70",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/nested-clients": "^3.997.37",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/credential-provider-imds": "^4.4.13",
@@ -233,13 +233,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.69.tgz",
-      "integrity": "sha512-gM3j0Ie9+FoLNTYODY+QWbg3vCRBc7mR9cRdntxTMkFYIrwfRmuucfavP6HNBlYSuaYww54TNJGej4GFgoPZAg==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.70.tgz",
+      "integrity": "sha512-JlUjK6bYJAxN9PkWWCI/TiOYEdvXNKq61x2DTaEKxRMxAOYNk2LX8m4wVtDFxTZwyXx7Tpmxb49dNprkW/uqXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
@@ -250,17 +250,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.73",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.73.tgz",
-      "integrity": "sha512-VTzdbf8Ukjdb9yUubZzRI678CWZvKovhE8Nv3qihwhC187sRMGls+r9N8Wuht5q1xjKx2nmpS48ar8ppupjkCA==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.74.tgz",
+      "integrity": "sha512-V+7pzT0OzROL2uKcQ2+MpnfwKONvozYojmdn8RguAMX9o48gtSVvt+7aCkwWCH2thDXOnUPCN6qn4kiFDelZWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.62",
-        "@aws-sdk/credential-provider-http": "^3.972.64",
-        "@aws-sdk/credential-provider-ini": "^3.973.7",
-        "@aws-sdk/credential-provider-process": "^3.972.62",
-        "@aws-sdk/credential-provider-sso": "^3.973.6",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.68",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-ini": "^3.973.8",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/credential-provider-imds": "^4.4.13",
@@ -272,12 +272,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.62",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.62.tgz",
-      "integrity": "sha512-zXYU9UWNL66gtMgNLhmxlrvEokuI7r6G2q7FRGu41Bya4iS30JLelUipJX9SV4zhyCPWJhI9Li54R1d9H8Tq6A==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.63.tgz",
+      "integrity": "sha512-lPt2oGMcvP3uPhhxX5EquHrzBI/ZgJce+CHKcOGZl2ZQAXLLSxu7k/Cgo0HIktyi9dmDFljbOkj4XAnXD93YVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/core": "^3.977.2",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
@@ -288,14 +288,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.6.tgz",
-      "integrity": "sha512-DobZggy3K49xdCpjeyMou0FQhkoYbluVGNydL6D+lcxF8GoAsttFX0xnH5GmiQ89We5dB6TRpW+CD/VowBH6HQ==",
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.7.tgz",
+      "integrity": "sha512-FR2b+7QNXP/q+eslVzrCjGKvso8Lcr/B18BvFyD2iLNhq42XSo+wnh8FfX6mtqgaVsL1vuB27uGXuY+xUTa7pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/nested-clients": "^3.997.36",
-        "@aws-sdk/token-providers": "3.1096.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/token-providers": "3.1097.0",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
@@ -306,13 +306,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.68.tgz",
-      "integrity": "sha512-bq+yTt+uWJx60VVp/OIAX5xqUAu/K2Uc3eknWnWl+KtfcU2CQe0uNw6lySrn2t5GKHq7jsV0Z63HiBGVtzr/lg==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.69.tgz",
+      "integrity": "sha512-RWNTKGXRkzMJe8bgIAdlz9q0N97m7fThD9KOjBt2CSY+/xnIbrA1/Dnm/ZEz8ZeQ1Of5D+fLaPeoD3lGt6AU4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
@@ -323,12 +323,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.67.tgz",
-      "integrity": "sha512-aB1ahF9z4J5r8YK1QodwNX/P8XSKBFtnjf7h72XCs0BP3rtThOiXeA3Lm+Z+8tiN9Iwl5otsGeHaXmQoQ5MVfA==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.68.tgz",
+      "integrity": "sha512-JA/LRxCSXQAsFHyIZzgncYdcTQTOL3ZS8R7EAeDwoSoWcNG8yxDAacrwFTZIyVSMvkogvlKHRvmrMU68UyQbkw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/core": "^3.977.2",
         "@aws-sdk/signature-v4-multi-region": "^3.996.42",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
@@ -340,12 +340,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.36.tgz",
-      "integrity": "sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg==",
+      "version": "3.997.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.37.tgz",
+      "integrity": "sha512-vfDmA6APjX1LWxvt6/zcAmTCgRXCj35M+bC9Ujmy40QxYs9Fa9bE7oblOB3ODZ4mdN9R5osU0hTzoJjJlQqqTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/core": "^3.977.2",
         "@aws-sdk/signature-v4-multi-region": "^3.996.42",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
@@ -359,12 +359,12 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1096.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1096.0.tgz",
-      "integrity": "sha512-vyWoSQwoWLAr/rB06vstzOXLWFCrRvyTz5HQC0jwZ51oEe+GKCIvF671AHicUfiwiVjNZ257VponbCWmrzj0Kw==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1097.0.tgz",
+      "integrity": "sha512-TgmZH1nCj26l5eNM/kxpQYwDtEWsB6jRi4bVFYipMFR2Mch815Gw/g0jkavNU0RUdYIqyPv6mzaQ545KC2Jdqw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/core": "^3.977.2",
         "@aws-sdk/signature-v4-multi-region": "^3.996.42",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
@@ -391,13 +391,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1096.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1096.0.tgz",
-      "integrity": "sha512-hdUS2hDppy3vkWeFl5y86RLNU6OWH2mQB09yOSsRefwhhGTSFPkaZvfLDD/9vFcvMzlr8QFQFw3fw2FtrurVQA==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1097.0.tgz",
+      "integrity": "sha512-EIsdmy/f5IGc5r01RjKWNvrbBra6z0xudQM0D6Wf8DeGuPoRlubkLqr7VgWijFucO4kg0mtev9H3RX/ZOubUhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,9 +27,9 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1096.0",
-    "@aws-sdk/client-sesv2": "^3.1096.0",
-    "@aws-sdk/s3-request-presigner": "^3.1096.0",
+    "@aws-sdk/client-s3": "^3.1097.0",
+    "@aws-sdk/client-sesv2": "^3.1097.0",
+    "@aws-sdk/s3-request-presigner": "^3.1097.0",
     "@prisma/adapter-pg": "^7.9.1",
     "@prisma/client": "^7.9.1",
     "@sentry/node": "^10.66.0",


### PR DESCRIPTION
Daily Upgrade Scan — auto-fix batch (backend, AWS SDK caret-only patch bumps).

| Package | From | To |
| --- | --- | --- |
| `@aws-sdk/client-s3` | 3.1096.0 | 3.1097.0 |
| `@aws-sdk/client-sesv2` | 3.1096.0 | 3.1097.0 |
| `@aws-sdk/s3-request-presigner` | 3.1096.0 | 3.1097.0 |

All three bumps are patch-level and remain within the existing `^3.1096.0` caret ranges.

### Quality gates
- `npm run type-check` → PASS
- `npm test` → PASS (58 suites, 942 tests)
- Diff guard: only `backend/package.json` and `backend/package-lock.json`

### CVE refs
None — routine AWS SDK maintenance.

Auto-merge (squash) will be enabled once CI is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2hkhP9xLoVydcWbV73co5)_