### PR TITLE
chore(deps): bump mobile patch deps (2026-07-29)

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mobile",
       "version": "1.0.0",
       "dependencies": {
-        "@amplitude/analytics-react-native": "^1.6.7",
+        "@amplitude/analytics-react-native": "^1.6.8",
         "@amplitude/analytics-types": "^2.11.1",
         "@expo-google-fonts/inter": "^0.4.2",
         "@expo-google-fonts/oswald": "^0.4.2",
@@ -90,9 +90,9 @@
       "license": "MIT"
     },
     "node_modules/@amplitude/analytics-core": {
-      "version": "2.54.0",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.54.0.tgz",
-      "integrity": "sha512-xZEpG5IQvRA6qBTnG+chANEeATL9oqOvQUrqKbwl+q0gX9a6skplUMBwhEhBv2iwuDAJhDF2+G2mYf7XGuEX4Q==",
+      "version": "2.54.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.54.1.tgz",
+      "integrity": "sha512-VMpcIPw7MBM9glKwTZivMiPeUSysY06LZr0Rsdl35szJqKIl3JAuVPR8UnRyYOxqDUZfkOPIm9w1+3E/NNtWVw==",
       "license": "MIT",
       "dependencies": {
         "@amplitude/analytics-connector": "^1.6.4",
@@ -103,13 +103,13 @@
       }
     },
     "node_modules/@amplitude/analytics-react-native": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.6.7.tgz",
-      "integrity": "sha512-1cYl11WVSUDxj0u6owAbyvby5m46HnYzhclUVuIfIrd/Pnhe958OSgsWBMphHtIv1QI0SB9OCx3DPfYKXvbUHw==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.6.8.tgz",
+      "integrity": "sha512-s/n5yKLcoobuj4u62D4M8VJGXOPrGR6RrnFfN5gO0uzDPQJNEeSoFDO6k4mPygMEox6MLVBfCXKt9Zk1xbujMA==",
       "license": "MIT",
       "dependencies": {
-        "@amplitude/analytics-core": "2.54.0",
-        "@amplitude/plugin-network-capture-browser": "1.10.11",
+        "@amplitude/analytics-core": "2.54.1",
+        "@amplitude/plugin-network-capture-browser": "1.10.12",
         "@amplitude/ua-parser-js": "^0.7.31",
         "@react-native-async-storage/async-storage": "^1.17.11",
         "tslib": "^2.4.1"
@@ -126,12 +126,12 @@
       "license": "MIT"
     },
     "node_modules/@amplitude/plugin-network-capture-browser": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/@amplitude/plugin-network-capture-browser/-/plugin-network-capture-browser-1.10.11.tgz",
-      "integrity": "sha512-CbqUWu1fiGow6aCdMY1V/ybOan+39LJKfmnh5paZYQTsjTo5UUYGG6dzncuTqHlyx80nWQTt8UbaCux7g22vHA==",
+      "version": "1.10.12",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-network-capture-browser/-/plugin-network-capture-browser-1.10.12.tgz",
+      "integrity": "sha512-FYdyMhPoToBL1GslOd7QjLctdhaL24sLKNGgXtYNVE8PiJNbmGNHWxf4Tr/CZ69uAuByXzo3Nvc0fGHpRIXiiQ==",
       "license": "MIT",
       "dependencies": {
-        "@amplitude/analytics-core": "2.54.0",
+        "@amplitude/analytics-core": "2.54.1",
         "tslib": "^2.4.1"
       }
     },

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,7 +15,7 @@
     "eas-build-on-success": "node scripts/sentry-upload-sourcemaps.js"
   },
   "dependencies": {
-    "@amplitude/analytics-react-native": "^1.6.7",
+    "@amplitude/analytics-react-native": "^1.6.8",
     "@amplitude/analytics-types": "^2.11.1",
     "@expo-google-fonts/inter": "^0.4.2",
     "@expo-google-fonts/oswald": "^0.4.2",


### PR DESCRIPTION
Daily Upgrade Scan — auto-fix batch (mobile, caret-only patch bumps).

| Package | From | To |
| --- | --- | --- |
| `@amplitude/analytics-react-native` | 1.6.7 | 1.6.8 |

Patch bump within the existing `^1.6.7` caret range.

### Quality gates
- `npm run type-check` → PASS
- `npm test` → PASS (45 suites, 446 tests)
- `npx expo export --platform ios` → PASS
- Diff guard: only `mobile/package.json` and `mobile/package-lock.json`

### CVE refs
None — routine analytics SDK maintenance.

Auto-merge (squash) will be enabled once CI is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2hkhP9xLoVydcWbV73co5)_