### PR TITLE
chore(deps): bump backend patch deps (2026-08-02)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -49,7 +49,7 @@
         "socket.io-client": "^4.8.3",
         "supertest": "^7.1.3",
         "ts-jest": "^29.4.12",
-        "tsx": "^4.23.1",
+        "tsx": "^4.23.4",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.65.0"
       }
@@ -9161,9 +9161,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
-      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "version": "4.23.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.4.tgz",
+      "integrity": "sha512-ZiUQ8oT/KzN51mJUWPqARYqwFLFJZtGZipRkw1ynHMr9vy3eU77m5yfF3Gzm6meEg/beW+lUu3fHYgskTN2oVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -80,7 +80,7 @@
     "socket.io-client": "^4.8.3",
     "supertest": "^7.1.3",
     "ts-jest": "^29.4.12",
-    "tsx": "^4.23.1",
+    "tsx": "^4.23.4",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0"
   }


### PR DESCRIPTION
Batched caret-patch lockfile bumps from the Daily Upgrade Scan routine.

## Versions

| package | from   | to     |
| ------- | ------ | ------ |
| tsx     | 4.23.1 | 4.23.4 |

## CVE refs

None — this is a routine caret-patch batch, not a CVE-driven `overrides` fix. The Dependabot alerts API remained unreachable in this session (403 through the sandbox proxy), so no `overrides`-based fixes were considered today.

## Quality gates

- `npm run type-check` — clean
- `npm test` — 58 suites, 942 tests, 0 failures (~48s)

## Diff guard

`git diff --name-only` returned only `backend/package.json` and `backend/package-lock.json`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYG4n2nWeGUTYWYw4wnLuq)_