### PR TITLE
fix: invoke docs-check Stop hook via $CLAUDE_PROJECT_DIR

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/check-docs-updated.sh",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-docs-updated.sh\"",
             "timeout": 10,
             "statusMessage": "Checking docs are up to date with code changes..."
           }


### PR DESCRIPTION
The Stop hook registered in `.claude/settings.json` used a relative path (`bash .claude/hooks/check-docs-updated.sh`). Hooks inherit the session shell's working directory, so whenever the shell was parked in `backend/`/`mobile/`/`web/`, every turn ended with:

```
Stop hook error: Failed with non-blocking status code: bash: .claude/hooks/check-docs-updated.sh: No such file or directory
```

Using `$CLAUDE_PROJECT_DIR` (the documented pattern for project-relative hook scripts) makes the invocation cwd-independent. The script body needs no changes — it already resolves and cd's to the git toplevel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)